### PR TITLE
Add PassThroughTransformer<T> as first generic transformer

### DIFF
--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -42,7 +42,11 @@
   </Folder>
   <Folder Name="/benchmarks/" />
   <Folder Name="/examples/" />
-  <Folder Name="/src/" />
-  <Folder Name="/tests/" />
+  <Folder Name="/src/">
+    <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj" />
+  </Folder>
 </Solution>
 

--- a/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
@@ -44,6 +44,15 @@ public sealed class PassThroughTransformer<T> : ITransformWithCancellationAsync<
     where T : notnull
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="PassThroughTransformer{T}"/> class.
+    /// </summary>
+    public PassThroughTransformer()
+    {
+    }
+
+
+
+    /// <summary>
     /// Asynchronously yields each item from <paramref name="items"/> unchanged.
     /// </summary>
     /// <param name="items">The asynchronous source sequence.</param>

--- a/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields each item from the input sequence unchanged.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="PassThroughTransformer{T}"/> is useful as:
+/// </para>
+/// <list type="bullet">
+///   <item><description>A placeholder in an ETL pipeline when a transformer is required by the pipeline shape but no transformation is needed.</description></item>
+///   <item><description>A default implementation in dependency injection, letting consumers swap in a real transformer later without restructuring the pipeline.</description></item>
+///   <item><description>A test seam for verifying extractor/loader behaviour without a real transformer in the way.</description></item>
+/// </list>
+/// <para>
+/// This class deliberately does <b>not</b> inherit from <see cref="TransformerBase{TSource, TDestination, TProgress}"/>.
+/// Because it performs no work, it does not need progress reporting, skip/max item counts, or a reporting timer,
+/// and implementing the interface directly keeps the type minimal and allocation-free.
+/// </para>
+/// <para>
+/// Formerly known internally as <c>NoOpTransformer</c>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     var transformer = new PassThroughTransformer&lt;Customer&gt;();
+///     await foreach (var customer in transformer.TransformAsync(source))
+///     {
+///         // items are yielded unchanged
+///     }
+/// </code>
+/// </example>
+public sealed class PassThroughTransformer<T> : ITransformWithCancellationAsync<T, T>
+    where T : notnull
+{
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> unchanged.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the same items as <paramref name="items"/>, in the same order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+        return TransformAsyncCore(items, CancellationToken.None);
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> unchanged, observing the supplied
+    /// <paramref name="token"/> for cancellation.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <param name="token">A token to observe while enumerating the source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the same items as <paramref name="items"/>, in the same order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="token"/> was cancelled before or during enumeration.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items, CancellationToken token)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+        return TransformAsyncCore(items, token);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> TransformAsyncCore
+    (
+        IAsyncEnumerable<T> items,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))
+        {
+            token.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
@@ -50,6 +50,12 @@ public sealed class PassThroughTransformer<T> : ITransformWithCancellationAsync<
     /// <returns>
     /// An asynchronous sequence containing the same items as <paramref name="items"/>, in the same order.
     /// </returns>
+    /// <remarks>
+    /// Because no transformation is applied, this overload returns the source sequence directly
+    /// without allocating a wrapping iterator. Any cancellation must be supplied by the caller
+    /// via <c>.WithCancellation(token)</c> on the returned sequence, or by using the
+    /// <see cref="TransformAsync(IAsyncEnumerable{T}, CancellationToken)"/> overload.
+    /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
     public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
     {
@@ -63,7 +69,7 @@ public sealed class PassThroughTransformer<T> : ITransformWithCancellationAsync<
         }
 #pragma warning restore RCS1140
 #endif
-        return TransformAsyncCore(items, CancellationToken.None);
+        return items;
     }
 
 

--- a/src/Wolfgang.Etl.Transformers/Properties/AssemblyInfo.cs
+++ b/src/Wolfgang.Etl.Transformers/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolfgang.Etl.Transformers.Tests.Unit")]

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Version>0.1.0</Version>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.0.0</FileVersion>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Title>Wolfgang.Etl.Transformers</Title>
+    <Authors>Chris Wolfgang</Authors>
+    <Description>A collection of generic, broadly reusable transformers for use in ETL pipelines built on Wolfgang.Etl.Abstractions.</Description>
+    <Copyright>Copyright 2026 Chris Wolfgang</Copyright>
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Transformers</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Transformers</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <SignAssembly>False</SignAssembly>
+    <PackageTags>ETL;Extract-Transform-Load;Transformer;PassThrough;Identity;NoOp;Data-Pipeline;IAsyncEnumerable;Streaming;dotnet;Wolfgang-ETL;Wolfgang.Etl.Abstractions</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <!--
+    Microsoft.Bcl.AsyncInterfaces: the runtime assembly is built into net8+, so pre-net8 TFMs
+    get a full reference. The net8+ group pins the version with ExcludeAssets="runtime" to
+    prevent NuGet from resolving an older transitive version - no runtime assembly is copied.
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class PassThroughTransformerTests
+{
+    [Fact]
+    public async Task TransformAsync_when_source_has_items_yields_each_item_unchanged()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+        var sut = new PassThroughTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new PassThroughTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_for_each_item()
+    {
+        var item1 = new Box<int>(1);
+        var item2 = new Box<int>(2);
+        var source = new[] { item1, item2 };
+        var sut = new PassThroughTransformer<Box<int>>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Same(item1, result[0]);
+        Assert.Same(item2, result[1]);
+    }
+
+
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new PassThroughTransformer<int>();
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void TransformAsync_with_cancellation_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new PassThroughTransformer<int>();
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!, CancellationToken.None)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_cancellation_already_requested_throws_OperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var sut = new PassThroughTransformer<int>();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.TransformAsync(ToAsync(new[] { 1, 2, 3 }), cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_cancelled_mid_enumeration_throws_OperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        var sut = new PassThroughTransformer<int>();
+        var yielded = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.TransformAsync(ToAsync(InfiniteSource()), cts.Token))
+                {
+                    yielded++;
+                    if (yielded == 3)
+                    {
+                        cts.Cancel();
+                    }
+                }
+            }
+        );
+
+        Assert.True(yielded >= 3);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_without_cancellation_completes_normally()
+    {
+        var source = new[] { "a", "b", "c" };
+        var sut = new PassThroughTransformer<string>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_CancellationToken_None_completes_normally()
+    {
+        var source = new[] { "a", "b", "c" };
+        var sut = new PassThroughTransformer<string>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source), CancellationToken.None));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_items()
+    {
+        var source = Enumerable.Range(0, 100).ToArray();
+        var sut = new PassThroughTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public void PassThroughTransformer_implements_ITransformAsync()
+    {
+        var sut = new PassThroughTransformer<int>();
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    [Fact]
+    public void PassThroughTransformer_implements_ITransformWithCancellationAsync()
+    {
+        var sut = new PassThroughTransformer<int>();
+
+        Assert.IsAssignableFrom<ITransformWithCancellationAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    private static IEnumerable<int> InfiniteSource()
+    {
+        var i = 0;
+        while (true)
+        {
+            yield return i++;
+        }
+    }
+
+
+
+    private sealed class Box<T>
+    {
+        public Box(T value)
+        {
+            Value = value;
+        }
+
+
+
+        public T Value { get; }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Introduces the `Wolfgang.Etl.Transformers` library with its first transformer, `PassThroughTransformer<T>`, which yields each input item unchanged.
- Useful as a pipeline placeholder, a DI default, or a test seam when a transformer is required by the pipeline shape but no transformation is needed.
- Formerly known internally as `NoOpTransformer` (documentation-only reference; no code alias).

## Design notes

- `PassThroughTransformer<T>` implements `ITransformWithCancellationAsync<T, T>` directly instead of inheriting from `TransformerBase<TSource, TDestination, TProgress>`. Because the type performs no work, it does not need progress reporting, skip/max item counts, or the reporting timer that `TransformerBase` provides; implementing the interface keeps the type minimal.
- Single type parameter `T : notnull` — since the transform is identity, source and destination are the same type by construction.
- Both overloads (`TransformAsync(items)` and `TransformAsync(items, token)`) throw `ArgumentNullException` when `items` is null. Cancellation is observed with `[EnumeratorCancellation]` plus a per-iteration `ThrowIfCancellationRequested()`.

## Project structure

- `src/Wolfgang.Etl.Transformers` — multi-targets `net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0` to match `Wolfgang.Etl.Abstractions` 0.12.0.
- `tests/Wolfgang.Etl.Transformers.Tests.Unit` — xunit 2.9.3, runs against all 13 standard test TFMs (net462-net481, netcoreapp3.1, net5.0-net10.0).

## Test plan

- [x] Builds clean on all 11 source TFMs (0 warnings, 0 errors)
- [x] Builds clean on all 13 test TFMs
- [x] 12/12 tests pass on net10.0
- [x] 12/12 tests pass on net8.0
- [x] 12/12 tests pass on net462
- [x] Coverage on `PassThroughTransformer<T>`: 100% line, 100% method
- [ ] CI pipeline validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)