### PR TITLE
Add 10 LINQ-equivalent lightweight transformers + benchmarks

### DIFF
--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -40,7 +40,9 @@
     <File Path="scripts/Setup-Labels.ps1" />
     <File Path="scripts/setup.ps1" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />

--- a/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereBenchmarks.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+
+
+namespace Wolfgang.Etl.Transformers.Benchmarks;
+
+/// <summary>
+/// Compares the lightweight <see cref="WhereTransformer{T}"/> (direct <c>ITransformAsync</c>
+/// implementation) against <see cref="WhereTransformerWithBase{T}"/> (inherits
+/// <see cref="Wolfgang.Etl.Abstractions.TransformerBase{TSource, TDestination, TProgress}"/>)
+/// to quantify the overhead of the shared base class on a pure-filter workload.
+/// </summary>
+[MemoryDiagnoser]
+public class WhereBenchmarks
+{
+    private int[] _source = Array.Empty<int>();
+    private Func<int, bool> _predicate = _ => true;
+
+
+
+    [Params(1_000, 100_000, 1_000_000)]
+    public int ItemCount { get; set; }
+
+
+
+    [Params(0.1, 0.5, 0.9)]
+    public double PassRate { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _source = new int[ItemCount];
+        for (var i = 0; i < ItemCount; i++)
+        {
+            _source[i] = i;
+        }
+
+        // Keep a consistent modulo threshold so JIT/branch-predictor behaviour is stable.
+        // PassRate of 0.1 -> item % 10 == 0 (keep 10%)
+        // PassRate of 0.5 -> item % 2  == 0 (keep 50%)
+        // PassRate of 0.9 -> item % 10 != 0 (keep 90%)
+        _predicate = PassRate switch
+        {
+            0.1 => i => i % 10 == 0,
+            0.5 => i => i % 2 == 0,
+            0.9 => i => i % 10 != 0,
+            _   => _ => true,
+        };
+    }
+
+
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> Lightweight()
+    {
+        var sut = new WhereTransformer<int>(_predicate);
+        var count = 0;
+        await foreach (var _ in sut.TransformAsync(ToAsync(_source)).ConfigureAwait(continueOnCapturedContext: false))
+        {
+            count++;
+        }
+        return count;
+    }
+
+
+
+    [Benchmark]
+    public async Task<int> WithBase()
+    {
+        var sut = new WhereTransformerWithBase<int>(_predicate);
+        var count = 0;
+        await foreach (var _ in sut.TransformAsync(ToAsync(_source)).ConfigureAwait(continueOnCapturedContext: false))
+        {
+            count++;
+        }
+        return count;
+    }
+
+
+
+    // Synchronously-completing async iterator. `await Task.CompletedTask` satisfies the
+    // async-method contract without forcing a scheduler hop per item - this way we measure
+    // the transformer's overhead, not the source's scheduling.
+    private static async IAsyncEnumerable<int> ToAsync(int[] items)
+    {
+        await Task.CompletedTask.ConfigureAwait(continueOnCapturedContext: false);
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereTransformerWithBase.cs
+++ b/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereTransformerWithBase.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers.Benchmarks;
+
+/// <summary>
+/// Alternate implementation of <see cref="WhereTransformer{T}"/> that inherits from
+/// <see cref="TransformerBase{TSource, TDestination, TProgress}"/> to measure the overhead
+/// of TransformerBase (Interlocked counters, progress timer plumbing, property fields,
+/// per-item ThrowIfCancellationRequested, WithCancellation wrapping) compared to the
+/// lightweight implementation shipped in the library.
+/// </summary>
+/// <remarks>
+/// This type is deliberately internal to the benchmarks project and does not leak into
+/// the public API of Wolfgang.Etl.Transformers. Any design mirrors the public
+/// <see cref="WhereTransformer{T}"/> where applicable (two ctors, propagation semantics,
+/// null checks).
+/// </remarks>
+public sealed class WhereTransformerWithBase<T> : TransformerBase<T, T, Report>
+    where T : notnull
+{
+    private readonly Func<T, bool>? _syncPredicate;
+    private readonly Func<T, ValueTask<bool>>? _asyncPredicate;
+
+
+
+    public WhereTransformerWithBase(Func<T, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        _syncPredicate = predicate;
+    }
+
+
+
+    public WhereTransformerWithBase(Func<T, ValueTask<bool>> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        _asyncPredicate = predicate;
+    }
+
+
+
+    protected override async IAsyncEnumerable<T> TransformWorkerAsync
+    (
+        IAsyncEnumerable<T> items,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        var skipRemaining = SkipItemCount;
+        var maxRemaining = MaximumItemCount;
+
+        await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))
+        {
+            token.ThrowIfCancellationRequested();
+
+            bool passed;
+            if (_syncPredicate is not null)
+            {
+                passed = _syncPredicate(item);
+            }
+            else
+            {
+                passed = await _asyncPredicate!(item).ConfigureAwait(continueOnCapturedContext: false);
+            }
+
+            if (!passed)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            if (skipRemaining > 0)
+            {
+                skipRemaining--;
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            if (maxRemaining <= 0)
+            {
+                yield break;
+            }
+
+            maxRemaining--;
+            IncrementCurrentItemCount();
+            yield return item;
+        }
+    }
+
+
+
+    protected override Report CreateProgressReport()
+    {
+        return new Report(CurrentItemCount);
+    }
+}

--- a/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/src/Wolfgang.Etl.Transformers/CastTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/CastTransformer.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that casts each input item to <typeparamref name="TDestination"/>, throwing
+/// <see cref="InvalidCastException"/> if any item is not of that type.
+/// </summary>
+/// <typeparam name="TSource">The type of items in the input sequence. Must be non-null.</typeparam>
+/// <typeparam name="TDestination">
+/// The type to cast to. Must be non-null. No compile-time relationship with
+/// <typeparamref name="TSource"/> is required - the cast is performed at runtime.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="CastTransformer{TSource, TDestination}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.Cast{TResult}(System.Collections.IEnumerable)"/>:
+/// it casts every input item to <typeparamref name="TDestination"/> and throws
+/// <see cref="InvalidCastException"/> if any item does not have a runtime conversion to that type.
+/// </para>
+/// <para>
+/// Use <see cref="OfTypeTransformer{TSource, TDestination}"/> instead when mismatched items
+/// should be silently filtered out rather than raise an exception.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // narrow a heterogeneous object stream to strings, asserting that every item is one
+///     var strings = new CastTransformer&lt;object, string&gt;();
+///
+///     // downcast every Animal to Dog (assumes the upstream guarantees this)
+///     var dogs = new CastTransformer&lt;Animal, Dog&gt;();
+/// </code>
+/// </example>
+public sealed class CastTransformer<TSource, TDestination> : ITransformAsync<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> cast to
+    /// <typeparamref name="TDestination"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence of the same items, cast to <typeparamref name="TDestination"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidCastException">
+    /// An item in <paramref name="items"/> is not assignable to <typeparamref name="TDestination"/>.
+    /// </exception>
+    public IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return CastAsync(items);
+    }
+
+
+
+    private static async IAsyncEnumerable<TDestination> CastAsync(IAsyncEnumerable<TSource> items)
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            yield return (TDestination)(object)item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/CastTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/CastTransformer.cs
@@ -46,6 +46,15 @@ public sealed class CastTransformer<TSource, TDestination> : ITransformAsync<TSo
     where TDestination : notnull
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="CastTransformer{TSource, TDestination}"/> class.
+    /// </summary>
+    public CastTransformer()
+    {
+    }
+
+
+
+    /// <summary>
     /// Asynchronously yields each item from <paramref name="items"/> cast to
     /// <typeparamref name="TDestination"/>.
     /// </summary>

--- a/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that batches the input sequence into arrays of a fixed size and yields each
+/// batch as a single output item.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="ChunkTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <c>Enumerable.Chunk</c> (introduced in .NET 6): it groups consecutive input items into
+/// <see cref="Size"/>-element arrays. The last chunk may be smaller than <see cref="Size"/>
+/// if the input length is not an exact multiple of <see cref="Size"/>.
+/// </para>
+/// <para>
+/// Each yielded chunk is a freshly-allocated <typeparamref name="T"/>[] - chunks do not share
+/// backing storage with the transformer or with each other. Consumers are free to retain or
+/// mutate each chunk without affecting subsequent output.
+/// </para>
+/// <para>
+/// Useful for batching writes to a downstream loader (e.g. <c>SqlBulkCopy</c>) without
+/// materializing the entire stream.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // batch rows into groups of 1000 for bulk loading
+///     var batches = new ChunkTransformer&lt;Row&gt;(size: 1000);
+/// </code>
+/// </example>
+public sealed class ChunkTransformer<T> : ITransformAsync<T, T[]>
+    where T : notnull
+{
+    private readonly int _size;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with the given chunk size.
+    /// </summary>
+    /// <param name="size">The maximum number of items in each yielded chunk. Must be at least 1.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is less than 1.</exception>
+    public ChunkTransformer(int size)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
+#else
+        if (size < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Chunk size must be greater than 0.");
+        }
+#endif
+
+        _size = size;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields successive chunks of <see cref="Size"/> consecutive items from
+    /// <paramref name="items"/>. The last chunk may contain fewer items if the source length
+    /// is not a multiple of <see cref="Size"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence of arrays, each containing up to <see cref="Size"/> items.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T[]> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return ChunkAsync(items, _size);
+    }
+
+
+
+    /// <summary>
+    /// The maximum number of items in each yielded chunk.
+    /// </summary>
+    public int Size => _size;
+
+
+
+    private static async IAsyncEnumerable<T[]> ChunkAsync(IAsyncEnumerable<T> items, int size)
+    {
+        var buffer = new T[size];
+        var index = 0;
+
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            buffer[index++] = item;
+
+            if (index == size)
+            {
+                yield return buffer;
+                buffer = new T[size];
+                index = 0;
+            }
+        }
+
+        if (index > 0)
+        {
+            // partial final chunk - copy to a right-sized array so the consumer
+            // sees only the items that were actually present
+            var partial = new T[index];
+            Array.Copy(buffer, partial, index);
+            yield return partial;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/DistinctByTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/DistinctByTransformer.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields each input item with a unique key, where the key is produced by a
+/// caller-supplied selector. Subsequent items whose key has already been seen are dropped.
+/// </summary>
+/// <typeparam name="TSource">The type of items in the input sequence. Must be non-null.</typeparam>
+/// <typeparam name="TKey">The type of key used for de-duplication. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="DistinctByTransformer{TSource, TKey}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.DistinctBy{TSource, TKey}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>.
+/// Keys are compared using either the supplied <see cref="IEqualityComparer{T}"/> or
+/// <see cref="EqualityComparer{T}.Default"/> if none is provided. Order is preserved: the
+/// item bearing the first occurrence of each key is yielded.
+/// </para>
+/// <para>
+/// The key selector is synchronous - key extraction is normally a cheap pure function (a
+/// property access, an integer ID, etc.) and an async overload would only add per-item
+/// overhead. If the key requires I/O to compute, project the key in a preceding
+/// <c>SelectTransformer</c> stage and use plain <see cref="DistinctTransformer{T}"/> on the
+/// result.
+/// </para>
+/// <para>
+/// <b>Memory footprint:</b> a fresh <see cref="HashSet{T}"/> of keys is allocated per call to
+/// <see cref="TransformAsync"/> and grows in proportion to the number of unique keys in the
+/// stream.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // first occurrence of each customer id
+///     var uniqueCustomers = new DistinctByTransformer&lt;Order, int&gt;(o =&gt; o.CustomerId);
+///
+///     // case-insensitive distinct by name
+///     var uniqueNames = new DistinctByTransformer&lt;Person, string&gt;
+///     (
+///         p =&gt; p.Name,
+///         StringComparer.OrdinalIgnoreCase
+///     );
+/// </code>
+/// </example>
+public sealed class DistinctByTransformer<TSource, TKey> : ITransformAsync<TSource, TSource>
+    where TSource : notnull
+    where TKey : notnull
+{
+    private readonly Func<TSource, TKey> _keySelector;
+    private readonly IEqualityComparer<TKey>? _comparer;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with the given key selector, using
+    /// <see cref="EqualityComparer{T}.Default"/> for key comparison.
+    /// </summary>
+    /// <param name="keySelector">A function that extracts the comparison key from an input item.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
+    public DistinctByTransformer(Func<TSource, TKey> keySelector)
+        : this(keySelector, comparer: null)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance with the given key selector and equality comparer.
+    /// </summary>
+    /// <param name="keySelector">A function that extracts the comparison key from an input item.</param>
+    /// <param name="comparer">
+    /// The comparer used to determine key equality. If <see langword="null"/>,
+    /// <see cref="EqualityComparer{T}.Default"/> is used.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
+    public DistinctByTransformer(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(keySelector);
+#else
+        if (keySelector == null)
+        {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+#endif
+
+        _keySelector = keySelector;
+        _comparer = comparer;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields the first item in <paramref name="items"/> for each unique key
+    /// produced by the configured selector, dropping later items with already-seen keys.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence containing the first item per distinct key.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<TSource> TransformAsync(IAsyncEnumerable<TSource> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return DistinctByAsync(items, _keySelector, _comparer);
+    }
+
+
+
+    private static async IAsyncEnumerable<TSource> DistinctByAsync
+    (
+        IAsyncEnumerable<TSource> items,
+        Func<TSource, TKey> keySelector,
+        IEqualityComparer<TKey>? comparer
+    )
+    {
+        var seen = new HashSet<TKey>(comparer);
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (seen.Add(keySelector(item)))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/DistinctByTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/DistinctByTransformer.cs
@@ -16,10 +16,10 @@ namespace Wolfgang.Etl.Transformers;
 /// <remarks>
 /// <para>
 /// <see cref="DistinctByTransformer{TSource, TKey}"/> is the transformer equivalent of LINQ's
-/// <see cref="System.Linq.Enumerable.DistinctBy{TSource, TKey}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>.
-/// Keys are compared using either the supplied <see cref="IEqualityComparer{T}"/> or
-/// <see cref="EqualityComparer{T}.Default"/> if none is provided. Order is preserved: the
-/// item bearing the first occurrence of each key is yielded.
+/// <c>Enumerable.DistinctBy</c> (introduced in .NET 6). Keys are compared using either the
+/// supplied <see cref="IEqualityComparer{T}"/> or <see cref="EqualityComparer{T}.Default"/>
+/// if none is provided. Order is preserved: the item bearing the first occurrence of each
+/// key is yielded.
 /// </para>
 /// <para>
 /// The key selector is synchronous - key extraction is normally a cheap pure function (a

--- a/src/Wolfgang.Etl.Transformers/DistinctTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/DistinctTransformer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields each unique item from the input sequence, dropping subsequent
+/// duplicates.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="DistinctTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.Distinct{TSource}(System.Collections.Generic.IEnumerable{TSource})"/>.
+/// Items are compared using either the supplied <see cref="IEqualityComparer{T}"/> or
+/// <see cref="EqualityComparer{T}.Default"/> if none is provided. Order is preserved: the
+/// first occurrence of each item is yielded.
+/// </para>
+/// <para>
+/// <b>Memory footprint:</b> a fresh <see cref="HashSet{T}"/> is allocated per call to
+/// <see cref="TransformAsync"/> and grows in proportion to the number of unique items in the
+/// stream. For unbounded streams or streams with many unique items, prefer
+/// <see cref="DistinctByTransformer{TSource, TKey}"/> with a small key type, or apply Distinct
+/// only after a stage that bounds cardinality.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // default equality
+///     var unique = new DistinctTransformer&lt;string&gt;();
+///
+///     // case-insensitive
+///     var insensitive = new DistinctTransformer&lt;string&gt;(StringComparer.OrdinalIgnoreCase);
+/// </code>
+/// </example>
+public sealed class DistinctTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly IEqualityComparer<T>? _comparer;
+
+
+
+    /// <summary>
+    /// Initializes a new instance using <see cref="EqualityComparer{T}.Default"/>.
+    /// </summary>
+    public DistinctTransformer() : this(comparer: null)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance using the supplied equality comparer.
+    /// </summary>
+    /// <param name="comparer">
+    /// The comparer used to determine equality. If <see langword="null"/>,
+    /// <see cref="EqualityComparer{T}.Default"/> is used.
+    /// </param>
+    public DistinctTransformer(IEqualityComparer<T>? comparer)
+    {
+        _comparer = comparer;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields the first occurrence of each unique item in <paramref name="items"/>,
+    /// dropping later duplicates.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence containing each item from <paramref name="items"/> at most once.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return DistinctAsync(items, _comparer);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> DistinctAsync
+    (
+        IAsyncEnumerable<T> items,
+        IEqualityComparer<T>? comparer
+    )
+    {
+        var seen = new HashSet<T>(comparer);
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (seen.Add(item))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/OfTypeTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/OfTypeTransformer.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields each input item that is of type <typeparamref name="TDestination"/>,
+/// silently skipping items of any other type.
+/// </summary>
+/// <typeparam name="TSource">The type of items in the input sequence. Must be non-null.</typeparam>
+/// <typeparam name="TDestination">
+/// The type to filter for. Must be non-null. No compile-time relationship with
+/// <typeparamref name="TSource"/> is required - the check is a runtime <c>is</c> test.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="OfTypeTransformer{TSource, TDestination}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.OfType{TResult}(System.Collections.IEnumerable)"/>:
+/// it filters and casts in a single step, yielding only items that satisfy
+/// <c>item is TDestination</c>.
+/// </para>
+/// <para>
+/// Items that do not match <typeparamref name="TDestination"/> are silently skipped - this
+/// transformer never throws <see cref="InvalidCastException"/>. Use
+/// <c>CastTransformer&lt;TSource, TDestination&gt;</c> instead if mismatched items should
+/// raise an exception rather than be filtered out.
+/// </para>
+/// <para>
+/// <see langword="null"/> items (which can technically appear if the source bypasses the
+/// <c>notnull</c> constraint via <c>null!</c>) are also skipped, since <c>null is T</c> is
+/// <see langword="false"/> for any <c>T</c>.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // pull the strings out of a heterogeneous object stream
+///     var strings = new OfTypeTransformer&lt;object, string&gt;();
+///
+///     // narrow an animal stream to only the dogs
+///     var dogs = new OfTypeTransformer&lt;Animal, Dog&gt;();
+/// </code>
+/// </example>
+public sealed class OfTypeTransformer<TSource, TDestination> : ITransformAsync<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> that is an instance of
+    /// <typeparamref name="TDestination"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing only those input items that are of type
+    /// <typeparamref name="TDestination"/>, cast to that type.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return FilterByTypeAsync(items);
+    }
+
+
+
+    private static async IAsyncEnumerable<TDestination> FilterByTypeAsync(IAsyncEnumerable<TSource> items)
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (item is TDestination typed)
+            {
+                yield return typed;
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/OfTypeTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/OfTypeTransformer.cs
@@ -53,6 +53,15 @@ public sealed class OfTypeTransformer<TSource, TDestination> : ITransformAsync<T
     where TDestination : notnull
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="OfTypeTransformer{TSource, TDestination}"/> class.
+    /// </summary>
+    public OfTypeTransformer()
+    {
+    }
+
+
+
+    /// <summary>
     /// Asynchronously yields each item from <paramref name="items"/> that is an instance of
     /// <typeparamref name="TDestination"/>.
     /// </summary>

--- a/src/Wolfgang.Etl.Transformers/SelectManyTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/SelectManyTransformer.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that projects each input item to a sequence of zero or more output items
+/// and yields the concatenation of all those sequences.
+/// </summary>
+/// <typeparam name="TSource">The type of items in the input sequence. Must be non-null.</typeparam>
+/// <typeparam name="TDestination">The type of items produced by the selector. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="SelectManyTransformer{TSource, TDestination}"/> is the transformer equivalent of
+/// LINQ's <see cref="System.Linq.Enumerable.SelectMany{TSource, TResult}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, System.Collections.Generic.IEnumerable{TResult}})"/>:
+/// it flattens a one-to-many projection into a single output stream.
+/// </para>
+/// <para>
+/// Two constructors are provided:
+/// </para>
+/// <list type="bullet">
+///   <item><description>A synchronous selector returning <see cref="IEnumerable{T}"/> for in-memory expansions.</description></item>
+///   <item><description>An asynchronous selector returning <see cref="IAsyncEnumerable{T}"/> for streamed expansions such as a paged database query or a chunked HTTP response.</description></item>
+/// </list>
+/// <para>
+/// Output is emitted depth-first: all items produced by the selector for the first input item
+/// are yielded before any items produced for the second input item, and so on.
+/// </para>
+/// <para>
+/// This type implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress,
+/// no cancellation, no Skip/Max - to keep the hot loop minimal. Compose with dedicated
+/// transformers when those concerns are needed.
+/// </para>
+/// <para>
+/// Exceptions thrown by the selector or by enumerating the returned sequence propagate to the
+/// caller. If the selector returns <see langword="null"/> a <see cref="NullReferenceException"/>
+/// will be raised on iteration, matching the behaviour of LINQ's
+/// <see cref="System.Linq.Enumerable.SelectMany{TSource, TResult}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, System.Collections.Generic.IEnumerable{TResult}})"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // synchronous fan-out: each Order yields all of its OrderLines
+///     var lines = new SelectManyTransformer&lt;Order, OrderLine&gt;(o =&gt; o.Lines);
+///
+///     // asynchronous fan-out: each customer id yields a paged stream of related orders
+///     var orders = new SelectManyTransformer&lt;int, Order&gt;
+///     (
+///         id =&gt; orderService.StreamForCustomerAsync(id)
+///     );
+/// </code>
+/// </example>
+public sealed class SelectManyTransformer<TSource, TDestination> : ITransformAsync<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    private readonly Func<TSource, IEnumerable<TDestination>>? _syncSelector;
+    private readonly Func<TSource, IAsyncEnumerable<TDestination>>? _asyncSelector;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with a synchronous selector that returns an
+    /// <see cref="IEnumerable{T}"/> for each input item.
+    /// </summary>
+    /// <param name="selector">A function that maps each input item to zero or more output items.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
+    public SelectManyTransformer(Func<TSource, IEnumerable<TDestination>> selector)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(selector);
+#else
+        if (selector == null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+#endif
+
+        _syncSelector = selector;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance with an asynchronous selector that returns an
+    /// <see cref="IAsyncEnumerable{T}"/> for each input item.
+    /// </summary>
+    /// <param name="selector">
+    /// A function that maps each input item to an asynchronous sequence of zero or more output items.
+    /// Useful for streamed inner expansions such as paged database queries.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
+    public SelectManyTransformer(Func<TSource, IAsyncEnumerable<TDestination>> selector)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(selector);
+#else
+        if (selector == null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+#endif
+
+        _asyncSelector = selector;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields the concatenation of the per-item sequences produced by the
+    /// configured selector.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous flattened sequence of items produced by the selector.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _syncSelector is not null
+            ? FlattenWithSyncSelectorAsync(items, _syncSelector)
+            : FlattenWithAsyncSelectorAsync(items, _asyncSelector!);
+    }
+
+
+
+    private static async IAsyncEnumerable<TDestination> FlattenWithSyncSelectorAsync
+    (
+        IAsyncEnumerable<TSource> items,
+        Func<TSource, IEnumerable<TDestination>> selector
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            foreach (var inner in selector(item))
+            {
+                yield return inner;
+            }
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<TDestination> FlattenWithAsyncSelectorAsync
+    (
+        IAsyncEnumerable<TSource> items,
+        Func<TSource, IAsyncEnumerable<TDestination>> selector
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            await foreach (var inner in selector(item).ConfigureAwait(continueOnCapturedContext: false))
+            {
+                yield return inner;
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/SkipTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/SkipTransformer.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that skips a fixed number of items from the start of the input sequence and
+/// yields the rest unchanged.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="SkipTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.Skip{TSource}(System.Collections.Generic.IEnumerable{TSource}, int)"/>:
+/// it discards the first <c>Count</c> items and yields everything after them.
+/// </para>
+/// <para>
+/// A <c>count</c> of <c>0</c> or negative is not an error - the transformer yields the source
+/// unchanged (matches the BCL contract for <c>Enumerable.Skip</c>). When <c>count &lt;= 0</c>
+/// the source is returned directly without a wrapping iterator, so this is essentially free.
+/// </para>
+/// <para>
+/// Useful for skipping headers, hopping past already-processed rows, or as a building block in
+/// composed pipelines when the upstream extractor does not expose a row-skip property.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // skip the first row (header) before processing the rest
+///     var dataOnly = new SkipTransformer&lt;Row&gt;(count: 1);
+/// </code>
+/// </example>
+public sealed class SkipTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly int _count;
+
+
+
+    /// <summary>
+    /// Initializes a new instance that skips the first <paramref name="count"/> items.
+    /// </summary>
+    /// <param name="count">
+    /// The number of items to skip from the start of the source. A value of <c>0</c> or less
+    /// yields the source unchanged.
+    /// </param>
+    public SkipTransformer(int count)
+    {
+        _count = count;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields all items from <paramref name="items"/> after skipping the first
+    /// <see cref="Count"/> of them.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the items from <paramref name="items"/> after
+    /// position <see cref="Count"/>. Empty if the source has <see cref="Count"/> or fewer
+    /// items. The source <paramref name="items"/> directly when <see cref="Count"/> is
+    /// <c>0</c> or negative.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _count <= 0
+            ? items
+            : SkipAsync(items, _count);
+    }
+
+
+
+    /// <summary>
+    /// The number of items this transformer will skip from the start of the source.
+    /// </summary>
+    public int Count => _count;
+
+
+
+    private static async IAsyncEnumerable<T> SkipAsync(IAsyncEnumerable<T> items, int count)
+    {
+        var skipped = 0;
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (skipped < count)
+            {
+                skipped++;
+                continue;
+            }
+
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/SkipWhileTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/SkipWhileTransformer.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that skips items from the start of the input sequence as long as a
+/// caller-supplied predicate returns <see langword="true"/>; once the predicate returns
+/// <see langword="false"/> for an item, that item and every item after it are yielded without
+/// further predicate evaluation.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="SkipWhileTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.SkipWhile{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, bool})"/>.
+/// The predicate is called on each item only until it first returns <see langword="false"/>;
+/// after that, every remaining item flows through unchanged.
+/// </para>
+/// <para>
+/// Two constructors are provided: one for synchronous predicates and one for asynchronous
+/// predicates returning <see cref="ValueTask{TResult}"/>. The asynchronous form is useful for
+/// I/O-bound start conditions such as a state-check against an external system.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// <para>
+/// Exceptions thrown by the predicate propagate to the caller.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // skip leading blank rows; once a non-blank row appears, yield everything from there
+///     var fromFirstReal = new SkipWhileTransformer&lt;Row&gt;(r =&gt; r.IsBlank);
+/// </code>
+/// </example>
+public sealed class SkipWhileTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly Func<T, bool>? _syncPredicate;
+    private readonly Func<T, ValueTask<bool>>? _asyncPredicate;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with a synchronous predicate.
+    /// </summary>
+    /// <param name="predicate">A function that returns <see langword="true"/> while items should be skipped.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public SkipWhileTransformer(Func<T, bool> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _syncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance with an asynchronous predicate.
+    /// </summary>
+    /// <param name="predicate">
+    /// A function that asynchronously returns <see langword="true"/> while items should be skipped.
+    /// Useful for I/O-bound start conditions.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public SkipWhileTransformer(Func<T, ValueTask<bool>> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _asyncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously skips items from the start of <paramref name="items"/> while the
+    /// configured predicate returns <see langword="true"/>, then yields the rest unchanged.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing every item from the first one where the predicate
+    /// returns <see langword="false"/> to the end of <paramref name="items"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _syncPredicate is not null
+            ? SkipWhileWithSyncPredicateAsync(items, _syncPredicate)
+            : SkipWhileWithAsyncPredicateAsync(items, _asyncPredicate!);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> SkipWhileWithSyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, bool> predicate
+    )
+    {
+        var skipping = true;
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (skipping)
+            {
+                if (predicate(item))
+                {
+                    continue;
+                }
+
+                skipping = false;
+            }
+
+            yield return item;
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> SkipWhileWithAsyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, ValueTask<bool>> predicate
+    )
+    {
+        var skipping = true;
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (skipping)
+            {
+                if (await predicate(item).ConfigureAwait(continueOnCapturedContext: false))
+                {
+                    continue;
+                }
+
+                skipping = false;
+            }
+
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/TakeTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/TakeTransformer.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields at most a fixed number of items from the start of the input
+/// sequence.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="TakeTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.Take{TSource}(System.Collections.Generic.IEnumerable{TSource}, int)"/>:
+/// it yields the first <c>Count</c> items from the source and stops, never enumerating beyond
+/// what was requested.
+/// </para>
+/// <para>
+/// A <c>count</c> of <c>0</c> or negative is not an error - the transformer yields no items and
+/// does not enumerate the source at all (matches the BCL contract for <c>Enumerable.Take</c>).
+/// </para>
+/// <para>
+/// Useful for windowing the head of a stream when the upstream extractor does not expose a
+/// row-count limit, and as a building block in composed pipelines.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // sample the first 100 rows for a dev / debug loop
+///     var head = new TakeTransformer&lt;Row&gt;(count: 100);
+/// </code>
+/// </example>
+public sealed class TakeTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly int _count;
+
+
+
+    /// <summary>
+    /// Initializes a new instance that yields at most <paramref name="count"/> items.
+    /// </summary>
+    /// <param name="count">
+    /// The maximum number of items to yield. A value of <c>0</c> or less results in an empty
+    /// output sequence and the source is not enumerated.
+    /// </param>
+    public TakeTransformer(int count)
+    {
+        _count = count;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields at most <see cref="Count"/> items from the start of
+    /// <paramref name="items"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the first <see cref="Count"/> items from
+    /// <paramref name="items"/>, or all items if the source is shorter than <see cref="Count"/>.
+    /// Empty if <see cref="Count"/> is <c>0</c> or negative.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _count <= 0
+            ? EmptyAsync()
+            : TakeAsync(items, _count);
+    }
+
+
+
+    /// <summary>
+    /// The maximum number of items this transformer will yield.
+    /// </summary>
+    public int Count => _count;
+
+
+
+    private static async IAsyncEnumerable<T> EmptyAsync()
+    {
+        await Task.CompletedTask.ConfigureAwait(continueOnCapturedContext: false);
+        yield break;
+    }
+
+
+
+    private static async IAsyncEnumerable<T> TakeAsync(IAsyncEnumerable<T> items, int count)
+    {
+        var taken = 0;
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            yield return item;
+            taken++;
+            if (taken >= count)
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/TakeWhileTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/TakeWhileTransformer.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields items from the start of the input sequence as long as a
+/// caller-supplied predicate returns <see langword="true"/>; the first item that fails
+/// the predicate stops enumeration immediately and is not yielded.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="TakeWhileTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.TakeWhile{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, bool})"/>:
+/// once the predicate returns <see langword="false"/> for an item, the transformer stops -
+/// the failing item is not yielded and the source is not enumerated beyond it.
+/// </para>
+/// <para>
+/// Two constructors are provided: one for synchronous predicates and one for asynchronous
+/// predicates returning <see cref="ValueTask{TResult}"/>. The asynchronous form is useful for
+/// I/O-bound stop conditions such as a state-check against an external system.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
+/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// </para>
+/// <para>
+/// Exceptions thrown by the predicate propagate to the caller.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // take rows until the first one that's incomplete
+///     var head = new TakeWhileTransformer&lt;Row&gt;(r =&gt; r.IsComplete);
+/// </code>
+/// </example>
+public sealed class TakeWhileTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly Func<T, bool>? _syncPredicate;
+    private readonly Func<T, ValueTask<bool>>? _asyncPredicate;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with a synchronous predicate.
+    /// </summary>
+    /// <param name="predicate">A function that returns <see langword="true"/> while items should continue to be yielded.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public TakeWhileTransformer(Func<T, bool> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _syncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance with an asynchronous predicate.
+    /// </summary>
+    /// <param name="predicate">
+    /// A function that asynchronously returns <see langword="true"/> while items should continue to be yielded.
+    /// Useful for I/O-bound stop conditions.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public TakeWhileTransformer(Func<T, ValueTask<bool>> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _asyncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields items from the start of <paramref name="items"/> while the
+    /// configured predicate returns <see langword="true"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the leading run of items for which the predicate
+    /// returns <see langword="true"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _syncPredicate is not null
+            ? TakeWhileWithSyncPredicateAsync(items, _syncPredicate)
+            : TakeWhileWithAsyncPredicateAsync(items, _asyncPredicate!);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> TakeWhileWithSyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, bool> predicate
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (!predicate(item))
+            {
+                yield break;
+            }
+
+            yield return item;
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> TakeWhileWithAsyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, ValueTask<bool>> predicate
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (!await predicate(item).ConfigureAwait(continueOnCapturedContext: false))
+            {
+                yield break;
+            }
+
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/WhereTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/WhereTransformer.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that yields each item from the input sequence for which a caller-supplied
+/// predicate returns <see langword="true"/>.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="WhereTransformer{T}"/> is the transformer equivalent of LINQ's
+/// <see cref="System.Linq.Enumerable.Where{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, bool})"/>:
+/// it tests each input item against a predicate and yields only those that pass.
+/// </para>
+/// <para>
+/// Two constructors are provided: one for synchronous predicates and one for asynchronous
+/// predicates returning <see cref="ValueTask{TResult}"/>. The asynchronous form is useful for
+/// I/O-bound filter conditions such as a database existence check.
+/// </para>
+/// <para>
+/// This type deliberately implements only <see cref="ITransformAsync{TSource, TDestination}"/> and
+/// does <b>not</b> inherit from <see cref="TransformerBase{TSource, TDestination, TProgress}"/>.
+/// It carries no progress reporting, no cancellation token, and no item counters - keeping the
+/// hot loop as small as possible for use as a building block in composed pipelines. Callers needing
+/// cancellation or windowing should compose with dedicated transformers (for example a future
+/// <c>SkipTransformer</c> / <c>TakeTransformer</c> / <c>BufferedTransformer</c>).
+/// </para>
+/// <para>
+/// Exceptions thrown by the predicate propagate to the caller. Callers that need to handle errors
+/// per item should do so inside the predicate itself.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     // synchronous filter
+///     var activeOnly = new WhereTransformer&lt;Customer&gt;(c =&gt; c.IsActive);
+///
+///     // asynchronous filter (I/O-bound)
+///     var existsInDb = new WhereTransformer&lt;int&gt;
+///     (
+///         async id =&gt; await db.CustomerExistsAsync(id).ConfigureAwait(false)
+///     );
+/// </code>
+/// </example>
+public sealed class WhereTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly Func<T, bool>? _syncPredicate;
+    private readonly Func<T, ValueTask<bool>>? _asyncPredicate;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with a synchronous predicate.
+    /// </summary>
+    /// <param name="predicate">A function that returns <see langword="true"/> for items to be yielded.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public WhereTransformer(Func<T, bool> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _syncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance with an asynchronous predicate.
+    /// </summary>
+    /// <param name="predicate">
+    /// A function that asynchronously returns <see langword="true"/> for items to be yielded.
+    /// Useful for I/O-bound filter conditions.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public WhereTransformer(Func<T, ValueTask<bool>> predicate)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(predicate);
+#else
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+#endif
+
+        _asyncPredicate = predicate;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> for which the configured
+    /// predicate returns <see langword="true"/>.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence containing only the items that satisfy the predicate.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _syncPredicate is not null
+            ? FilterWithSyncPredicateAsync(items, _syncPredicate)
+            : FilterWithAsyncPredicateAsync(items, _asyncPredicate!);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> FilterWithSyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, bool> predicate
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (predicate(item))
+            {
+                yield return item;
+            }
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> FilterWithAsyncPredicateAsync
+    (
+        IAsyncEnumerable<T> items,
+        Func<T, ValueTask<bool>> predicate
+    )
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (await predicate(item).ConfigureAwait(continueOnCapturedContext: false))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class CastTransformerTests
+{
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new CastTransformer<object, string>();
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new CastTransformer<object, string>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<object>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- all items cast successfully ----------
+
+    [Fact]
+    public async Task TransformAsync_when_all_items_match_destination_type_yields_them_cast()
+    {
+        var sut = new CastTransformer<object, string>();
+        var source = new object[] { "a", "b", "c" };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { "a", "b", "c" }, result);
+    }
+
+
+
+    // ---------- subtype downcast ----------
+
+    [Fact]
+    public async Task TransformAsync_downcasts_subtypes_in_an_inheritance_hierarchy()
+    {
+        var rex = new Dog("Rex");
+        var buddy = new Dog("Buddy");
+        var sut = new CastTransformer<Animal, Dog>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new Animal[] { rex, buddy })));
+
+        Assert.Same(rex, result[0]);
+        Assert.Same(buddy, result[1]);
+    }
+
+
+
+    // ---------- mismatched type throws ----------
+
+    [Fact]
+    public async Task TransformAsync_when_an_item_is_not_assignable_throws_InvalidCastException()
+    {
+        var sut = new CastTransformer<object, string>();
+        var source = new object[] { "a", 1, "b" };
+
+        await Assert.ThrowsAsync<InvalidCastException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(source)))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_throws_InvalidCastException_on_first_mismatch_yielding_prior_items()
+    {
+        var sut = new CastTransformer<object, string>();
+        var source = new object[] { "a", "b", 42, "c" };
+        var collected = new List<string>();
+
+        await Assert.ThrowsAsync<InvalidCastException>
+        (
+            async () =>
+            {
+                await foreach (var item in sut.TransformAsync(ToAsync(source)))
+                {
+                    collected.Add(item);
+                }
+            }
+        );
+
+        Assert.Equal(new[] { "a", "b" }, collected);
+    }
+
+
+
+    // ---------- mismatched subtype downcast throws ----------
+
+    [Fact]
+    public async Task TransformAsync_when_subtype_downcast_encounters_wrong_subtype_throws()
+    {
+        var sut = new CastTransformer<Animal, Dog>();
+        var source = new Animal[] { new Dog("Rex"), new Cat("Whiskers") };
+
+        await Assert.ThrowsAsync<InvalidCastException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(source)))
+        );
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_for_yielded_items()
+    {
+        var rex = new Dog("Rex");
+        var buddy = new Dog("Buddy");
+        var sut = new CastTransformer<Animal, Dog>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new Animal[] { rex, buddy })));
+
+        Assert.Collection
+        (
+            result,
+            d => Assert.Same(rex, d),
+            d => Assert.Same(buddy, d)
+        );
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_items()
+    {
+        var sut = new CastTransformer<object, int>();
+        var source = new object[] { 1, 2, 3, 4, 5 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result);
+    }
+
+
+
+    // ---------- value types (boxing) ----------
+
+    [Fact]
+    public async Task TransformAsync_unboxes_value_types_correctly()
+    {
+        var sut = new CastTransformer<object, int>();
+        var source = new object[] { 10, 20, 30 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { 10, 20, 30 }, result);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void CastTransformer_implements_ITransformAsync()
+    {
+        var sut = new CastTransformer<object, string>();
+
+        Assert.IsAssignableFrom<ITransformAsync<object, string>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    // test fixtures
+
+    private abstract class Animal
+    {
+        protected Animal(string name)
+        {
+            Name = name;
+        }
+
+
+
+        public string Name { get; }
+    }
+
+
+
+    private sealed class Dog : Animal
+    {
+        public Dog(string name) : base(name)
+        {
+        }
+    }
+
+
+
+    private sealed class Cat : Animal
+    {
+        public Cat(string name) : base(name)
+        {
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class ChunkTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_when_size_is_zero_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new ChunkTransformer<int>(size: 0)
+        );
+
+        Assert.Equal("size", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_when_size_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new ChunkTransformer<int>(size: -3)
+        );
+
+        Assert.Equal("size", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_size_one_succeeds()
+    {
+        var sut = new ChunkTransformer<int>(size: 1);
+
+        Assert.Equal(1, sut.Size);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new ChunkTransformer<int>(size: 5);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_chunks()
+    {
+        var sut = new ChunkTransformer<int>(size: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- exact division ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_length_is_exact_multiple_yields_full_chunks()
+    {
+        var sut = new ChunkTransformer<int>(size: 3);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Enumerable.Range(1, 9).ToArray())));
+
+        Assert.Collection
+        (
+            result,
+            chunk => Assert.Equal(new[] { 1, 2, 3 }, chunk),
+            chunk => Assert.Equal(new[] { 4, 5, 6 }, chunk),
+            chunk => Assert.Equal(new[] { 7, 8, 9 }, chunk)
+        );
+    }
+
+
+
+    // ---------- partial final chunk ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_does_not_divide_evenly_yields_smaller_final_chunk()
+    {
+        var sut = new ChunkTransformer<int>(size: 3);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Enumerable.Range(1, 10).ToArray())));
+
+        Assert.Collection
+        (
+            result,
+            chunk => Assert.Equal(new[] { 1, 2, 3 }, chunk),
+            chunk => Assert.Equal(new[] { 4, 5, 6 }, chunk),
+            chunk => Assert.Equal(new[] { 7, 8, 9 }, chunk),
+            chunk => Assert.Equal(new[] { 10 }, chunk)
+        );
+    }
+
+
+
+    // ---------- source shorter than size ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_shorter_than_size_yields_one_partial_chunk()
+    {
+        var sut = new ChunkTransformer<int>(size: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2 })));
+
+        Assert.Single(result);
+        Assert.Equal(new[] { 1, 2 }, result[0]);
+    }
+
+
+
+    // ---------- size = 1 ----------
+
+    [Fact]
+    public async Task TransformAsync_when_size_is_one_yields_one_chunk_per_item()
+    {
+        var sut = new ChunkTransformer<int>(size: 1);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 10, 20, 30 })));
+
+        Assert.Collection
+        (
+            result,
+            chunk => Assert.Equal(new[] { 10 }, chunk),
+            chunk => Assert.Equal(new[] { 20 }, chunk),
+            chunk => Assert.Equal(new[] { 30 }, chunk)
+        );
+    }
+
+
+
+    // ---------- size larger than source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_size_exceeds_source_yields_single_chunk_with_all_items()
+    {
+        var sut = new ChunkTransformer<int>(size: 1000);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Single(result);
+        Assert.Equal(new[] { 1, 2, 3 }, result[0]);
+    }
+
+
+
+    // ---------- chunks are independent arrays (no aliasing) ----------
+
+    [Fact]
+    public async Task TransformAsync_yields_independent_chunk_arrays()
+    {
+        var sut = new ChunkTransformer<int>(size: 2);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4 })));
+
+        Assert.Equal(2, result.Count);
+        Assert.NotSame(result[0], result[1]);
+
+        // Mutating one chunk must not affect the other
+        result[0][0] = 999;
+        Assert.Equal(new[] { 3, 4 }, result[1]);
+    }
+
+
+
+    // ---------- partial final chunk is right-sized ----------
+
+    [Fact]
+    public async Task TransformAsync_partial_final_chunk_is_sized_to_actual_item_count()
+    {
+        var sut = new ChunkTransformer<int>(size: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7 })));
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(5, result[0].Length);
+        Assert.Equal(2, result[1].Length);   // not 5 with default trailing values
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_across_chunks()
+    {
+        var sut = new ChunkTransformer<int>(size: 7);
+        var source = Enumerable.Range(1, 100).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        var flattened = result.SelectMany(c => c).ToArray();
+        Assert.Equal(source, flattened);
+    }
+
+
+
+    // ---------- reference identity within chunk ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_of_items_within_chunks()
+    {
+        var a = new Box(1);
+        var b = new Box(2);
+        var c = new Box(3);
+
+        var sut = new ChunkTransformer<Box>(size: 2);
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b, c })));
+
+        Assert.Same(a, result[0][0]);
+        Assert.Same(b, result[0][1]);
+        Assert.Same(c, result[1][0]);
+    }
+
+
+
+    // ---------- Size property ----------
+
+    [Fact]
+    public void Size_property_reflects_constructor_argument()
+    {
+        Assert.Equal(7, new ChunkTransformer<int>(size: 7).Size);
+        Assert.Equal(1, new ChunkTransformer<int>(size: 1).Size);
+        Assert.Equal(int.MaxValue, new ChunkTransformer<int>(size: int.MaxValue).Size);
+        // Note: a buffer is only allocated when TransformAsync is enumerated, so
+        // constructing with int.MaxValue here is harmless.
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void ChunkTransformer_implements_ITransformAsync()
+    {
+        var sut = new ChunkTransformer<int>(size: 1);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int[]>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    // test fixtures
+
+    private sealed class Box
+    {
+        public Box(int value)
+        {
+            Value = value;
+        }
+
+
+
+        public int Value { get; }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctByTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctByTransformerTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class DistinctByTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_when_keySelector_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new DistinctByTransformer<Person, int>(keySelector: null!)
+        );
+
+        Assert.Equal("keySelector", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_comparer_when_keySelector_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new DistinctByTransformer<Person, int>(null!, EqualityComparer<int>.Default)
+        );
+
+        Assert.Equal("keySelector", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<Person>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- all unique keys ----------
+
+    [Fact]
+    public async Task TransformAsync_when_all_keys_are_unique_yields_all_items()
+    {
+        var p1 = new Person(1, "Alice");
+        var p2 = new Person(2, "Bob");
+        var p3 = new Person(3, "Carol");
+
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { p1, p2, p3 })));
+
+        Assert.Equal(new[] { p1, p2, p3 }, result);
+    }
+
+
+
+    // ---------- duplicate keys ----------
+
+    [Fact]
+    public async Task TransformAsync_yields_first_item_per_distinct_key()
+    {
+        var p1a = new Person(1, "Alice");
+        var p1b = new Person(1, "Alicia");   // same id, different name
+        var p2 = new Person(2, "Bob");
+
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { p1a, p1b, p2 })));
+
+        Assert.Collection
+        (
+            result,
+            p => Assert.Same(p1a, p),
+            p => Assert.Same(p2, p)
+        );
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_first_occurrences()
+    {
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+        var people = new[]
+        {
+            new Person(3, "C"),
+            new Person(1, "A"),
+            new Person(2, "B"),
+            new Person(1, "A2"),
+            new Person(3, "C2"),
+        };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(people)));
+
+        Assert.Equal(new[] { 3, 1, 2 }, result.Select(p => p.Id));
+    }
+
+
+
+    // ---------- custom comparer ----------
+
+    [Fact]
+    public async Task TransformAsync_uses_supplied_key_comparer()
+    {
+        var sut = new DistinctByTransformer<Person, string>
+        (
+            p => p.Name,
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        var people = new[]
+        {
+            new Person(1, "Alice"),
+            new Person(2, "ALICE"),  // same name case-insensitively
+            new Person(3, "Bob"),
+        };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(people)));
+
+        Assert.Collection
+        (
+            result,
+            p => Assert.Equal(1, p.Id),
+            p => Assert.Equal(3, p.Id)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_comparer_is_null_uses_default_equality()
+    {
+        var sut = new DistinctByTransformer<Person, string>(p => p.Name, comparer: null);
+
+        var people = new[]
+        {
+            new Person(1, "Alice"),
+            new Person(2, "ALICE"),
+            new Person(3, "Bob"),
+        };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(people)));
+
+        // case-sensitive default → all three are kept
+        Assert.Equal(3, result.Count);
+    }
+
+
+
+    // ---------- key selector exception propagates ----------
+
+    [Fact]
+    public async Task TransformAsync_when_key_selector_throws_exception_propagates()
+    {
+        Func<Person, int> selector = _ => throw new InvalidOperationException("key-boom");
+        var sut = new DistinctByTransformer<Person, int>(selector);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { new Person(1, "A") })))
+        );
+
+        Assert.Equal("key-boom", ex.Message);
+    }
+
+
+
+    // ---------- fresh state per call ----------
+
+    [Fact]
+    public async Task TransformAsync_uses_fresh_state_on_each_call()
+    {
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+        var people = new[] { new Person(1, "A"), new Person(2, "B") };
+
+        var first = await CollectAsync(sut.TransformAsync(ToAsync(people)));
+        var second = await CollectAsync(sut.TransformAsync(ToAsync(people)));
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(2, second.Count);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void DistinctByTransformer_implements_ITransformAsync()
+    {
+        var sut = new DistinctByTransformer<Person, int>(p => p.Id);
+
+        Assert.IsAssignableFrom<ITransformAsync<Person, Person>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    // test fixtures
+
+    private sealed class Person
+    {
+        public Person(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+
+
+        public int Id { get; }
+
+
+
+        public string Name { get; }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctTransformerTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class DistinctTransformerTests
+{
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- all unique ----------
+
+    [Fact]
+    public async Task TransformAsync_when_all_items_are_unique_yields_all_items()
+    {
+        var sut = new DistinctTransformer<int>();
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    // ---------- all duplicates ----------
+
+    [Fact]
+    public async Task TransformAsync_when_all_items_are_the_same_yields_first_only()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 7, 7, 7, 7, 7 })));
+
+        Assert.Equal(new[] { 7 }, result);
+    }
+
+
+
+    // ---------- mixed ----------
+
+    [Fact]
+    public async Task TransformAsync_yields_first_occurrence_of_each_distinct_item()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 1, 3, 2, 4, 1, 5 })));
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_first_occurrences()
+    {
+        var sut = new DistinctTransformer<string>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { "c", "a", "b", "a", "c", "d" })));
+
+        Assert.Equal(new[] { "c", "a", "b", "d" }, result);
+    }
+
+
+
+    // ---------- custom comparer ----------
+
+    [Fact]
+    public async Task TransformAsync_uses_supplied_comparer()
+    {
+        var sut = new DistinctTransformer<string>(StringComparer.OrdinalIgnoreCase);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { "Apple", "BANANA", "apple", "banana", "Cherry" })));
+
+        Assert.Equal(new[] { "Apple", "BANANA", "Cherry" }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_comparer_is_null_uses_default_equality()
+    {
+        var sut = new DistinctTransformer<string>(comparer: null);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { "a", "A", "a", "A" })));
+
+        // default string equality is case-sensitive
+        Assert.Equal(new[] { "a", "A" }, result);
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_of_yielded_items()
+    {
+        var a1 = new Box(1);
+        var a2 = new Box(1); // equal value, different reference
+        var b = new Box(2);
+
+        var sut = new DistinctTransformer<Box>(BoxValueComparer.Instance);
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a1, a2, b })));
+
+        Assert.Collection
+        (
+            result,
+            x => Assert.Same(a1, x),  // first wins
+            x => Assert.Same(b, x)
+        );
+    }
+
+
+
+    // ---------- fresh state per call ----------
+
+    [Fact]
+    public async Task TransformAsync_uses_fresh_state_on_each_call()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        var first = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+        var second = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        // Second call should yield the same items - no leak from first
+        Assert.Equal(new[] { 1, 2, 3 }, first);
+        Assert.Equal(new[] { 1, 2, 3 }, second);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void DistinctTransformer_implements_ITransformAsync()
+    {
+        var sut = new DistinctTransformer<int>();
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    // test fixtures
+
+    private sealed class Box
+    {
+        public Box(int value)
+        {
+            Value = value;
+        }
+
+
+
+        public int Value { get; }
+    }
+
+
+
+    private sealed class BoxValueComparer : IEqualityComparer<Box>
+    {
+        public static readonly BoxValueComparer Instance = new();
+
+
+
+        public bool Equals(Box? x, Box? y) => (x?.Value) == (y?.Value);
+
+
+
+        public int GetHashCode(Box obj) => obj.Value.GetHashCode();
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/OfTypeTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/OfTypeTransformerTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class OfTypeTransformerTests
+{
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<object>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- all items match ----------
+
+    [Fact]
+    public async Task TransformAsync_when_all_items_match_destination_type_yields_all_items()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+        var source = new object[] { "a", "b", "c" };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { "a", "b", "c" }, result);
+    }
+
+
+
+    // ---------- no items match ----------
+
+    [Fact]
+    public async Task TransformAsync_when_no_items_match_destination_type_yields_empty_sequence()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+        var source = new object[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- mixed types ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_has_mixed_types_yields_only_matching_items()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+        var source = new object[] { "a", 1, "b", 2.0, "c", true };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { "a", "b", "c" }, result);
+    }
+
+
+
+    // ---------- subtype filtering ----------
+
+    [Fact]
+    public async Task TransformAsync_filters_to_specific_subtype_in_an_inheritance_hierarchy()
+    {
+        var sut = new OfTypeTransformer<Animal, Dog>();
+        var source = new Animal[]
+        {
+            new Dog("Rex"),
+            new Cat("Whiskers"),
+            new Dog("Buddy"),
+            new Cat("Mittens"),
+        };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Rex", result[0].Name);
+        Assert.Equal("Buddy", result[1].Name);
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_for_yielded_items()
+    {
+        var dog1 = new Dog("Rex");
+        var dog2 = new Dog("Buddy");
+        var cat = new Cat("Whiskers");
+
+        var sut = new OfTypeTransformer<Animal, Dog>();
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new Animal[] { dog1, cat, dog2 })));
+
+        Assert.Collection
+        (
+            result,
+            d => Assert.Same(dog1, d),
+            d => Assert.Same(dog2, d)
+        );
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_matching_items()
+    {
+        var sut = new OfTypeTransformer<object, int>();
+        var source = new object[] { 1, "skip", 2, "skip", 3, "skip", 4 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { 1, 2, 3, 4 }, result);
+    }
+
+
+
+    // ---------- never throws on type mismatch ----------
+
+    [Fact]
+    public async Task TransformAsync_does_not_throw_when_items_are_not_of_destination_type()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+        var source = new object[] { 1, 2.5, true, new object() };
+
+        // Should not throw even though no items can be cast to string
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void OfTypeTransformer_implements_ITransformAsync()
+    {
+        var sut = new OfTypeTransformer<object, string>();
+
+        Assert.IsAssignableFrom<ITransformAsync<object, string>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    // test fixtures
+
+    private abstract class Animal
+    {
+        protected Animal(string name)
+        {
+            Name = name;
+        }
+
+
+
+        public string Name { get; }
+    }
+
+
+
+    private sealed class Dog : Animal
+    {
+        public Dog(string name) : base(name)
+        {
+        }
+    }
+
+
+
+    private sealed class Cat : Animal
+    {
+        public Cat(string name) : base(name)
+        {
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectManyTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectManyTransformerTests.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class SelectManyTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_with_sync_selector_when_selector_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new SelectManyTransformer<int, int>((Func<int, IEnumerable<int>>)null!)
+        );
+
+        Assert.Equal("selector", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_async_selector_when_selector_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new SelectManyTransformer<int, int>((Func<int, IAsyncEnumerable<int>>)null!)
+        );
+
+        Assert.Equal("selector", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        Func<int, IEnumerable<int>> selector = i => new[] { i };
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- sync selector ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_selector_flattens_inner_sequences()
+    {
+        Func<int, IEnumerable<int>> selector = i => new[] { i, i * 10 };
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 10, 2, 20, 3, 30 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_selector_yields_nothing_for_empty_inner()
+    {
+        Func<int, IEnumerable<int>> selector = i => i % 2 == 0 ? new[] { i } : Array.Empty<int>();
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4 })));
+
+        Assert.Equal(new[] { 2, 4 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_selector_with_all_empty_inners_yields_empty_sequence()
+    {
+        Func<int, IEnumerable<int>> selector = _ => Array.Empty<int>();
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- async selector ----------
+
+    [Fact]
+    public async Task TransformAsync_async_selector_flattens_inner_sequences()
+    {
+        Func<int, IAsyncEnumerable<int>> selector = i => ToAsync(new[] { i, i * 10 });
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 10, 2, 20, 3, 30 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_selector_yields_nothing_for_empty_inner()
+    {
+        Func<int, IAsyncEnumerable<int>> selector =
+            i => i % 2 == 0 ? ToAsync(new[] { i }) : ToAsync(Array.Empty<int>());
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4 })));
+
+        Assert.Equal(new[] { 2, 4 }, result);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items_sync_selector()
+    {
+        Func<int, IEnumerable<int>> selector = i => new[] { i };
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items_async_selector()
+    {
+        Func<int, IAsyncEnumerable<int>> selector = i => ToAsync(new[] { i });
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- depth-first ordering ----------
+
+    [Fact]
+    public async Task TransformAsync_emits_inner_items_depth_first()
+    {
+        Func<int, IEnumerable<string>> selector =
+            i => new[] { $"{i}-a", $"{i}-b", $"{i}-c" };
+        var sut = new SelectManyTransformer<int, string>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2 })));
+
+        Assert.Equal
+        (
+            new[] { "1-a", "1-b", "1-c", "2-a", "2-b", "2-c" },
+            result
+        );
+    }
+
+
+
+    // ---------- exception propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_sync_selector_throws_exception_propagates()
+    {
+        Func<int, IEnumerable<int>> selector = _ => throw new InvalidOperationException("boom");
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_async_selector_throws_exception_propagates()
+    {
+        Func<int, IAsyncEnumerable<int>> selector =
+            _ => throw new InvalidOperationException("async-boom");
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("async-boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_inner_sync_iteration_throws_exception_propagates()
+    {
+        Func<int, IEnumerable<int>> selector = _ => ThrowingEnumerable();
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("inner-boom", ex.Message);
+
+        static IEnumerable<int> ThrowingEnumerable()
+        {
+            yield return 1;
+            throw new InvalidOperationException("inner-boom");
+        }
+    }
+
+
+
+    // ---------- cross-type projection ----------
+
+    [Fact]
+    public async Task TransformAsync_supports_changing_type_from_source_to_destination()
+    {
+        Func<string, IEnumerable<char>> selector = s => s.ToCharArray();
+        var sut = new SelectManyTransformer<string, char>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { "ab", "cd" })));
+
+        Assert.Equal(new[] { 'a', 'b', 'c', 'd' }, result);
+    }
+
+
+
+    // ---------- order preservation across many input items ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_global_ordering()
+    {
+        Func<int, IEnumerable<int>> selector = i => Enumerable.Range(i * 10, 3);
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 0, 1, 2 })));
+
+        Assert.Equal(new[] { 0, 1, 2, 10, 11, 12, 20, 21, 22 }, result);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void SelectManyTransformer_implements_ITransformAsync()
+    {
+        Func<int, IEnumerable<int>> selector = i => new[] { i };
+        var sut = new SelectManyTransformer<int, int>(selector);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipTransformerTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class SkipTransformerTests
+{
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new SkipTransformer<int>(count: 5);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new SkipTransformer<int>(count: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- count > source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_exceeds_source_yields_empty_sequence()
+    {
+        var sut = new SkipTransformer<int>(count: 10);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- count < source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_less_than_source_yields_remaining_items()
+    {
+        var sut = new SkipTransformer<int>(count: 2);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Equal(new[] { 3, 4, 5 }, result);
+    }
+
+
+
+    // ---------- count = source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_equals_source_yields_empty_sequence()
+    {
+        var sut = new SkipTransformer<int>(count: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- count = 0 ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_zero_yields_all_items()
+    {
+        var sut = new SkipTransformer<int>(count: 0);
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public void TransformAsync_when_count_is_zero_returns_source_directly()
+    {
+        var sut = new SkipTransformer<int>(count: 0);
+        var source = ToAsync(new[] { 1, 2, 3 });
+
+        var result = sut.TransformAsync(source);
+
+        Assert.Same(source, result);
+    }
+
+
+
+    // ---------- count < 0 ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_negative_yields_all_items()
+    {
+        var sut = new SkipTransformer<int>(count: -1);
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public void TransformAsync_when_count_is_negative_returns_source_directly()
+    {
+        var sut = new SkipTransformer<int>(count: -10);
+        var source = ToAsync(new[] { 1, 2, 3 });
+
+        var result = sut.TransformAsync(source);
+
+        Assert.Same(source, result);
+    }
+
+
+
+    // ---------- count = 1 (header skip) ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_one_skips_first_item()
+    {
+        var sut = new SkipTransformer<string>(count: 1);
+
+        var result = await CollectAsync
+        (
+            sut.TransformAsync(ToAsync(new[] { "header", "row1", "row2", "row3" }))
+        );
+
+        Assert.Equal(new[] { "row1", "row2", "row3" }, result);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_yielded_items()
+    {
+        var sut = new SkipTransformer<int>(count: 50);
+        var source = Enumerable.Range(1, 100).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(Enumerable.Range(51, 50), result);
+    }
+
+
+
+    // ---------- Count property ----------
+
+    [Fact]
+    public void Count_property_reflects_constructor_argument()
+    {
+        Assert.Equal(7, new SkipTransformer<int>(count: 7).Count);
+        Assert.Equal(0, new SkipTransformer<int>(count: 0).Count);
+        Assert.Equal(-3, new SkipTransformer<int>(count: -3).Count);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void SkipTransformer_implements_ITransformAsync()
+    {
+        var sut = new SkipTransformer<int>(count: 1);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipWhileTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipWhileTransformerTests.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class SkipWhileTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_with_sync_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new SkipWhileTransformer<int>((Func<int, bool>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_async_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new SkipWhileTransformer<int>((Func<int, ValueTask<bool>>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new SkipWhileTransformer<int>(_ => true);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- sync predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_skips_leading_items_then_yields_rest()
+    {
+        var sut = new SkipWhileTransformer<int>(i => i < 4);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6 })));
+
+        Assert.Equal(new[] { 4, 5, 6 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_first_item_fails_yields_all_items()
+    {
+        var sut = new SkipWhileTransformer<int>(i => i > 100);
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_all_items_pass_yields_empty_sequence()
+    {
+        var sut = new SkipWhileTransformer<int>(_ => true);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- async predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_skips_leading_items_then_yields_rest()
+    {
+        var sut = new SkipWhileTransformer<int>(i => new ValueTask<bool>(result: i < 4));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6 })));
+
+        Assert.Equal(new[] { 4, 5, 6 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_first_item_fails_yields_all_items()
+    {
+        var sut = new SkipWhileTransformer<int>(_ => new ValueTask<bool>(result: false));
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_all_items_pass_yields_empty_sequence()
+    {
+        var sut = new SkipWhileTransformer<int>(_ => new ValueTask<bool>(result: true));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new SkipWhileTransformer<int>(_ => true);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- predicate stops being called once first false hit ----------
+
+    [Fact]
+    public async Task TransformAsync_does_not_call_predicate_after_first_false_sync()
+    {
+        var calls = 0;
+        var sut = new SkipWhileTransformer<int>
+        (
+            i =>
+            {
+                Interlocked.Increment(ref calls);
+                return i < 3;
+            }
+        );
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })));
+
+        Assert.Equal(new[] { 3, 4, 5, 6, 7, 8, 9, 10 }, result);
+        // Predicate is called for items 1 (true), 2 (true), 3 (false).
+        // After that it should never be called again.
+        Assert.Equal(3, calls);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_does_not_call_predicate_after_first_false_async()
+    {
+        var calls = 0;
+        var sut = new SkipWhileTransformer<int>
+        (
+            i =>
+            {
+                Interlocked.Increment(ref calls);
+                return new ValueTask<bool>(result: i < 3);
+            }
+        );
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })));
+
+        Assert.Equal(new[] { 3, 4, 5, 6, 7, 8, 9, 10 }, result);
+        Assert.Equal(3, calls);
+    }
+
+
+
+    // ---------- failing item is yielded ----------
+
+    [Fact]
+    public async Task TransformAsync_yields_first_item_where_predicate_returns_false()
+    {
+        var sut = new SkipWhileTransformer<int>(i => i != 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7 })));
+
+        Assert.Equal(new[] { 5, 6, 7 }, result);
+        Assert.Contains(5, result);
+    }
+
+
+
+    // ---------- exception propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_sync_predicate_throws_exception_propagates()
+    {
+        Func<int, bool> predicate = _ => throw new InvalidOperationException("boom");
+        var sut = new SkipWhileTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_async_predicate_throws_exception_propagates()
+    {
+        Func<int, ValueTask<bool>> predicate = _ => throw new InvalidOperationException("async-boom");
+        var sut = new SkipWhileTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("async-boom", ex.Message);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_yielded_items()
+    {
+        var sut = new SkipWhileTransformer<int>(i => i < 50);
+        var source = Enumerable.Range(1, 100).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(Enumerable.Range(50, 51), result);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void SkipWhileTransformer_implements_ITransformAsync()
+    {
+        Func<int, bool> predicate = _ => true;
+        var sut = new SkipWhileTransformer<int>(predicate);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeTransformerTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class TakeTransformerTests
+{
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TakeTransformer<int>(count: 5);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new TakeTransformer<int>(count: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- count > source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_exceeds_source_yields_all_items()
+    {
+        var sut = new TakeTransformer<int>(count: 10);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    // ---------- count < source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_less_than_source_yields_first_count_items()
+    {
+        var sut = new TakeTransformer<int>(count: 3);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    // ---------- count = source count ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_equals_source_yields_all_items()
+    {
+        var sut = new TakeTransformer<int>(count: 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result);
+    }
+
+
+
+    // ---------- count = 0 ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_zero_yields_empty_sequence()
+    {
+        var sut = new TakeTransformer<int>(count: 0);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_zero_does_not_enumerate_source()
+    {
+        var enumerated = 0;
+        var sut = new TakeTransformer<int>(count: 0);
+
+        var result = await CollectAsync
+        (
+            sut.TransformAsync(CountingSource(new[] { 1, 2, 3 }, () => Interlocked.Increment(ref enumerated)))
+        );
+
+        Assert.Empty(result);
+        Assert.Equal(0, enumerated);
+    }
+
+
+
+    // ---------- count < 0 ----------
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_negative_yields_empty_sequence()
+    {
+        var sut = new TakeTransformer<int>(count: -1);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_count_is_negative_does_not_enumerate_source()
+    {
+        var enumerated = 0;
+        var sut = new TakeTransformer<int>(count: -5);
+
+        var result = await CollectAsync
+        (
+            sut.TransformAsync(CountingSource(new[] { 1, 2, 3 }, () => Interlocked.Increment(ref enumerated)))
+        );
+
+        Assert.Empty(result);
+        Assert.Equal(0, enumerated);
+    }
+
+
+
+    // ---------- early termination (does not enumerate beyond count) ----------
+
+    [Fact]
+    public async Task TransformAsync_stops_enumerating_source_after_count_items()
+    {
+        var enumerated = 0;
+        var sut = new TakeTransformer<int>(count: 3);
+
+        var result = await CollectAsync
+        (
+            sut.TransformAsync(CountingSource(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, () => Interlocked.Increment(ref enumerated)))
+        );
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(3, enumerated);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_yielded_items()
+    {
+        var sut = new TakeTransformer<int>(count: 50);
+        var source = Enumerable.Range(1, 100).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(Enumerable.Range(1, 50), result);
+    }
+
+
+
+    // ---------- Count property ----------
+
+    [Fact]
+    public void Count_property_reflects_constructor_argument()
+    {
+        Assert.Equal(7, new TakeTransformer<int>(count: 7).Count);
+        Assert.Equal(0, new TakeTransformer<int>(count: 0).Count);
+        Assert.Equal(-3, new TakeTransformer<int>(count: -3).Count);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void TakeTransformer_implements_ITransformAsync()
+    {
+        var sut = new TakeTransformer<int>(count: 1);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> CountingSource<T>(IEnumerable<T> items, Action onItem)
+    {
+        foreach (var item in items)
+        {
+            onItem();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeWhileTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeWhileTransformerTests.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class TakeWhileTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_with_sync_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TakeWhileTransformer<int>((Func<int, bool>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_async_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TakeWhileTransformer<int>((Func<int, ValueTask<bool>>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TakeWhileTransformer<int>(_ => true);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- sync predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_yields_items_until_first_false()
+    {
+        var sut = new TakeWhileTransformer<int>(i => i < 4);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_first_item_fails_yields_empty_sequence()
+    {
+        var sut = new TakeWhileTransformer<int>(i => i > 100);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_all_items_pass_yields_all_items()
+    {
+        var sut = new TakeWhileTransformer<int>(_ => true);
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    // ---------- async predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_yields_items_until_first_false()
+    {
+        var sut = new TakeWhileTransformer<int>(i => new ValueTask<bool>(result: i < 4));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_first_item_fails_yields_empty_sequence()
+    {
+        var sut = new TakeWhileTransformer<int>(_ => new ValueTask<bool>(result: false));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_all_items_pass_yields_all_items()
+    {
+        var sut = new TakeWhileTransformer<int>(_ => new ValueTask<bool>(result: true));
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new TakeWhileTransformer<int>(_ => true);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- early termination ----------
+
+    [Fact]
+    public async Task TransformAsync_stops_enumerating_source_after_first_failing_item()
+    {
+        var enumerated = 0;
+        var sut = new TakeWhileTransformer<int>(i => i < 4);
+
+        var result = await CollectAsync
+        (
+            sut.TransformAsync(CountingSource(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, () => Interlocked.Increment(ref enumerated)))
+        );
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        // The transformer reads items 1, 2, 3 (yield), then 4 (fails predicate, stops).
+        // Items 5-10 should not be enumerated.
+        Assert.Equal(4, enumerated);
+    }
+
+
+
+    // ---------- failing item is not yielded ----------
+
+    [Fact]
+    public async Task TransformAsync_does_not_yield_first_failing_item()
+    {
+        var sut = new TakeWhileTransformer<int>(i => i != 5);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7 })));
+
+        Assert.Equal(new[] { 1, 2, 3, 4 }, result);
+        Assert.DoesNotContain(5, result);
+    }
+
+
+
+    // ---------- exception propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_sync_predicate_throws_exception_propagates()
+    {
+        Func<int, bool> predicate = _ => throw new InvalidOperationException("boom");
+        var sut = new TakeWhileTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_async_predicate_throws_exception_propagates()
+    {
+        Func<int, ValueTask<bool>> predicate = _ => throw new InvalidOperationException("async-boom");
+        var sut = new TakeWhileTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("async-boom", ex.Message);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_yielded_items()
+    {
+        var sut = new TakeWhileTransformer<int>(i => i < 50);
+        var source = Enumerable.Range(1, 100).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(Enumerable.Range(1, 49), result);
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void TakeWhileTransformer_implements_ITransformAsync()
+    {
+        Func<int, bool> predicate = _ => true;
+        var sut = new TakeWhileTransformer<int>(predicate);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> CountingSource<T>(IEnumerable<T> items, Action onItem)
+    {
+        foreach (var item in items)
+        {
+            onItem();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/WhereTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/WhereTransformerTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class WhereTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_with_sync_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new WhereTransformer<int>((Func<int, bool>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_async_predicate_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new WhereTransformer<int>((Func<int, ValueTask<bool>>)null!)
+        );
+
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new WhereTransformer<int>(_ => true);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- sync predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_yields_only_items_where_predicate_is_true()
+    {
+        var sut = new WhereTransformer<int>(i => i % 2 == 0);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6 })));
+
+        Assert.Equal(new[] { 2, 4, 6 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_all_items_pass_yields_all_items()
+    {
+        var sut = new WhereTransformer<int>(_ => true);
+        var source = new[] { 1, 2, 3 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_predicate_when_no_items_pass_yields_empty_sequence()
+    {
+        var sut = new WhereTransformer<int>(_ => false);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- async predicate ----------
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_yields_only_items_where_predicate_is_true()
+    {
+        var sut = new WhereTransformer<int>(i => new ValueTask<bool>(i > 2));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5 })));
+
+        Assert.Equal(new[] { 3, 4, 5 }, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_all_items_pass_yields_all_items()
+    {
+        var sut = new WhereTransformer<int>(_ => new ValueTask<bool>(result: true));
+        var source = new[] { 10, 20, 30 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_predicate_when_no_items_pass_yields_empty_sequence()
+    {
+        var sut = new WhereTransformer<int>(_ => new ValueTask<bool>(result: false));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items_sync_predicate()
+    {
+        var sut = new WhereTransformer<int>(_ => true);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items_async_predicate()
+    {
+        var sut = new WhereTransformer<int>(_ => new ValueTask<bool>(result: true));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- exception propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_sync_predicate_throws_exception_propagates()
+    {
+        Func<int, bool> predicate = _ => throw new InvalidOperationException("boom");
+        var sut = new WhereTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_async_predicate_throws_exception_propagates()
+    {
+        Func<int, ValueTask<bool>> predicate = _ => throw new InvalidOperationException("async-boom");
+        var sut = new WhereTransformer<int>(predicate);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("async-boom", ex.Message);
+    }
+
+
+
+    // ---------- order preservation ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_of_passing_items()
+    {
+        var sut = new WhereTransformer<int>(i => i % 3 == 0);
+        var source = Enumerable.Range(1, 30).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(new[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30 }, result);
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_for_yielded_items()
+    {
+        var a = new Box(1);
+        var b = new Box(2);
+        var c = new Box(3);
+
+        Func<Box, bool> predicate = x => x.Value % 2 == 1;
+        var sut = new WhereTransformer<Box>(predicate);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b, c })));
+
+        Assert.Collection
+        (
+            result,
+            item => Assert.Same(a, item),
+            item => Assert.Same(c, item)
+        );
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void WhereTransformer_implements_ITransformAsync()
+    {
+        Func<int, bool> predicate = _ => true;
+        var sut = new WhereTransformer<int>(predicate);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    private sealed class Box
+    {
+        public Box(int value)
+        {
+            Value = value;
+        }
+
+
+
+        public int Value { get; }
+    }
+}


### PR DESCRIPTION
## Summary

Adds 10 LINQ-equivalent transformers to `Wolfgang.Etl.Transformers`, all built on a lightweight pattern (direct `ITransformAsync<TSource, TDestination>` implementation with no `TransformerBase`, no progress, no cancellation, no `Skip`/`Max`). Also introduces a benchmarks project that motivated the lightweight choice.

Stacked on top of #8 (`feature/select-transformer`). Retarget to `dev` once #8 merges.

## Transformers added (12 classes total — Distinct + DistinctBy count as one item)

| # | Type | Pattern |
|---|---|---|
| 1 | `WhereTransformer<T>` | filter; sync + async predicate ctors |
| 2 | `SelectManyTransformer<TSource, TDestination>` | flatten one-to-many; sync `IEnumerable` + async `IAsyncEnumerable` selector ctors |
| 3 | `OfTypeTransformer<TSource, TDestination>` | filter + cast; silently skips mismatches |
| 4 | `CastTransformer<TSource, TDestination>` | cast every item; throws `InvalidCastException` on mismatch |
| 5 | `TakeTransformer<T>` | first N items; matches `Enumerable.Take` (negative/zero count yields empty without enumerating) |
| 6 | `TakeWhileTransformer<T>` | yield while predicate holds; sync + async predicate ctors |
| 7 | `SkipTransformer<T>` | skip first N items; returns source directly when count ≤ 0 |
| 8 | `SkipWhileTransformer<T>` | skip while predicate holds; predicate stops being called once first false hit |
| 9 | `DistinctTransformer<T>` + `DistinctByTransformer<TSource, TKey>` | dedup by item / by key; HashSet-based, optional comparer |
| 10 | `ChunkTransformer<T>` | batch into `T[]` arrays; partial last chunk right-sized |

## Library-wide pattern

- **Direct `ITransformAsync` implementation** — no `TransformerBase`. Decision motivated by a 14–27% throughput delta measured on Where (see benchmarks below).
- **Sync + async lambda overloads** for every transformer that takes a predicate or selector. Two private iterator methods chosen at dispatch — no per-item branching, no sync→`ValueTask` wrapper closure allocations in the hot loop.
- **Async lambdas have no `CancellationToken` parameter** — these transformers don't support cancellation at the transformer level; callers compose with future cancellation/buffering primitives.
- **Null lambdas / null `items`** → `ArgumentNullException`.
- **Predicate / selector exceptions propagate**.
- **`sealed` classes**, `Wolfgang.Etl.Transformers` namespace.

## Benchmarks

`benchmarks/Wolfgang.Etl.Transformers.Benchmarks` (BenchmarkDotNet) compares lightweight Where against a `WhereTransformerWithBase` variant inheriting `TransformerBase<T, T, Report>` (variant lives only in the benchmarks project, not the public API). Matrix: 3 item counts (1k / 100k / 1M) × 3 selectivities (10% / 50% / 90% pass rate).

Findings on Intel i7-14700HX, .NET 10.0.7:

- Lightweight is **14–27% faster** across the matrix.
- Constant **+80 B per call** alloc overhead from `TransformerBase` (field storage); neither variant allocates per item in the hot path.
- Overhead concentrates on rejected items (`Interlocked` counter updates and `ThrowIfCancellationRequested` per item in `WithBase`).

These results drove:
1. Lightweight as the baseline for all 10 new transformers.
2. The rewrite of `SelectTransformer` to lightweight (in #8 — the prior commit on this stack).

## Issue

Also opened #9 to track adding `BufferedTransformer<T>` (standalone, not decorator) for pipeline parallelism via `System.Threading.Channels`. Standalone-vs-decorator design discussion captured there.

## Test plan

- [x] **176 xunit tests pass on net10.0** (12 PassThrough + 12 Select + 16 Where + 17 SelectMany + 10 OfType + 11 Cast + 13 Take + 16 TakeWhile + 13 Skip + 17 SkipWhile + 12 Distinct + 12 DistinctBy + 16 Chunk)
- [x] **176/176 pass on net462** (every TFM the source library targets)
- [x] **Source builds clean on all 11 source TFMs** (net462, net472, net48, net481, netstandard2.0, net5.0–net10.0)
- [x] **100% line + method coverage** on all 13 transformer types
- [x] **Benchmarks build and run clean**
- [ ] CI validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)