### PR TITLE
Add BufferedTransformer<T> for pipeline parallelism

### DIFF
--- a/src/Wolfgang.Etl.Transformers/BufferedTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/BufferedTransformer.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A transformer that decouples its upstream and downstream stages using a bounded
+/// <see cref="Channel{T}"/>, enabling pipeline parallelism: the upstream stage can run ahead
+/// while the downstream stage consumes, instead of being lock-stepped by
+/// <see cref="IAsyncEnumerable{T}"/>'s pull model.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// With plain <see cref="IAsyncEnumerable{T}"/> chaining, every stage runs on the same logical
+/// call path - throughput is bounded by the slowest stage and fast stages idle while waiting.
+/// Inserting a <see cref="BufferedTransformer{T}"/> between two stages introduces a producer
+/// task that drains the upstream into a bounded buffer; the downstream stage then reads from
+/// the buffer. The two sides run concurrently, so total throughput approaches
+/// <c>max(stage speeds)</c> rather than <c>min(stage speeds)</c>.
+/// </para>
+/// <para>
+/// The buffer is bounded - once full, the producer task awaits free space, providing
+/// backpressure on the source.
+/// </para>
+/// <para>
+/// <b>Cancellation:</b> consumers do not need a transformer-level token. External cancellation
+/// supplied via <c>.WithCancellation(token)</c> on the returned sequence is propagated to the
+/// internal producer task via a linked <see cref="CancellationTokenSource"/>, so the source
+/// enumerator and producer are cleaned up promptly.
+/// </para>
+/// <para>
+/// <b>Error propagation:</b> exceptions thrown by the source enumerator or by writes into the
+/// buffer are surfaced to the consumer through the channel - the consumer's <c>await foreach</c>
+/// throws the original exception (unwrapped) once any already-buffered items have drained.
+/// </para>
+/// <para>
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - matching the
+/// lightweight pattern of the rest of the library. The producer task's lifecycle is managed
+/// internally via the iterator's disposal contract.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     extractor
+///         .Pipe(new WhereTransformer&lt;Row&gt;(r =&gt; r.IsValid))
+///         .Pipe(new BufferedTransformer&lt;Row&gt;(capacity: 500))   // parallelism boundary
+///         .Pipe(new SelectTransformer&lt;Row, Record&gt;(Parse))
+///         .Pipe(loader);
+/// </code>
+/// </example>
+public sealed class BufferedTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly int _capacity;
+
+
+
+    /// <summary>
+    /// Initializes a new instance with the given buffer capacity.
+    /// </summary>
+    /// <param name="capacity">
+    /// The maximum number of items that may be buffered between the upstream and downstream
+    /// stages. Must be at least 1.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 1.</exception>
+    public BufferedTransformer(int capacity)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+#else
+        if (capacity < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Buffer capacity must be greater than 0.");
+        }
+#endif
+
+        _capacity = capacity;
+    }
+
+
+
+    /// <summary>
+    /// The maximum number of items the internal buffer holds.
+    /// </summary>
+    public int Capacity => _capacity;
+
+
+
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/>, with a bounded buffer
+    /// in between that allows the upstream and downstream stages to run concurrently.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence containing the same items as <paramref name="items"/>, in the same order.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return BufferAsync(items, _capacity);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> BufferAsync
+    (
+        IAsyncEnumerable<T> items,
+        int capacity,
+        [EnumeratorCancellation] CancellationToken externalToken = default
+    )
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+        var channel = Channel.CreateBounded<T>
+        (
+            new BoundedChannelOptions(capacity)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait,
+            }
+        );
+
+        var producer = Task.Run(() => PumpAsync(items, channel, cts.Token), cts.Token);
+
+        try
+        {
+            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token).ConfigureAwait(continueOnCapturedContext: false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+#if NET8_0_OR_GREATER
+            await cts.CancelAsync().ConfigureAwait(continueOnCapturedContext: false);
+#else
+#pragma warning disable VSTHRD103 // CancelAsync not available pre-net8
+            cts.Cancel();
+#pragma warning restore VSTHRD103
+#endif
+#pragma warning disable CA1031 // producer faults were already surfaced via the channel
+            try
+            {
+                await producer.ConfigureAwait(continueOnCapturedContext: false);
+            }
+            catch
+            {
+                // Swallow: any real fault was already delivered through the channel.
+            }
+#pragma warning restore CA1031
+        }
+    }
+
+
+
+    /// <summary>
+    /// The producer task body: drains the source into the channel, completing the channel
+    /// normally on natural end, or with an exception on fault. Cancellation - whether from
+    /// external <c>.WithCancellation</c> or from consumer abandonment - completes the channel
+    /// quietly without surfacing as a fault.
+    /// </summary>
+    private static async Task PumpAsync(IAsyncEnumerable<T> items, Channel<T> channel, CancellationToken token)
+    {
+        try
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))
+            {
+                await channel.Writer.WriteAsync(item, token).ConfigureAwait(continueOnCapturedContext: false);
+            }
+
+            channel.Writer.Complete();
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            channel.Writer.TryComplete();
+        }
+#pragma warning disable CA1031 // intentional: surface ANY producer fault to the consumer via the channel
+        catch (Exception ex)
+        {
+            channel.Writer.TryComplete(ex);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -22,6 +22,7 @@
     <SignAssembly>False</SignAssembly>
     <PackageTags>ETL;Extract-Transform-Load;Transformer;PassThrough;Identity;NoOp;Data-Pipeline;IAsyncEnumerable;Streaming;dotnet;Wolfgang-ETL;Wolfgang.Etl.Abstractions</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,6 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.Channels" Version="10.0.5" />
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.12.0" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class BufferedTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_when_capacity_is_zero_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new BufferedTransformer<int>(capacity: 0)
+        );
+
+        Assert.Equal("capacity", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_when_capacity_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new BufferedTransformer<int>(capacity: -3)
+        );
+
+        Assert.Equal("capacity", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_capacity_one_succeeds()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 1);
+
+        Assert.Equal(1, sut.Capacity);
+    }
+
+
+
+    [Fact]
+    public void Capacity_property_reflects_constructor_argument()
+    {
+        Assert.Equal(7, new BufferedTransformer<int>(capacity: 7).Capacity);
+        Assert.Equal(1024, new BufferedTransformer<int>(capacity: 1024).Capacity);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 10);
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- empty source ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_is_empty_yields_no_items()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 10);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- pass-through fidelity ----------
+
+    [Fact]
+    public async Task TransformAsync_yields_each_item_unchanged_in_order()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 10);
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_preserves_order_for_large_source_with_small_buffer()
+    {
+        // Source larger than buffer exercises backpressure: producer fills, waits, fills,
+        // waits, ... Consumer drains continuously. Output must still match source 1:1.
+        var sut = new BufferedTransformer<int>(capacity: 4);
+        var source = Enumerable.Range(1, 1000).ToArray();
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_of_yielded_items()
+    {
+        var a = new Box(1);
+        var b = new Box(2);
+        var c = new Box(3);
+
+        var sut = new BufferedTransformer<Box>(capacity: 8);
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b, c })));
+
+        Assert.Collection
+        (
+            result,
+            x => Assert.Same(a, x),
+            x => Assert.Same(b, x),
+            x => Assert.Same(c, x)
+        );
+    }
+
+
+
+    // ---------- producer error propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_source_throws_exception_propagates_to_consumer()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 4);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ThrowingSource()))
+        );
+
+        Assert.Equal("source-boom", ex.Message);
+
+        static async IAsyncEnumerable<int> ThrowingSource()
+        {
+            yield return 1;
+            yield return 2;
+            await Task.Yield();
+            throw new InvalidOperationException("source-boom");
+        }
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_source_throws_yields_already_buffered_items_first()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 100);
+        var collected = new List<int>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () =>
+            {
+                await foreach (var item in sut.TransformAsync(ThrowingAfterFive()))
+                {
+                    collected.Add(item);
+                }
+            }
+        );
+
+        // The first 5 items must have been delivered before the exception surfaced.
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, collected);
+
+        static async IAsyncEnumerable<int> ThrowingAfterFive()
+        {
+            for (var i = 1; i <= 5; i++)
+            {
+                yield return i;
+                await Task.Yield();
+            }
+            throw new InvalidOperationException("after-five-boom");
+        }
+    }
+
+
+
+    // ---------- consumer abandonment ----------
+
+    [Fact]
+    public async Task TransformAsync_when_consumer_breaks_early_disposes_source_enumerator()
+    {
+        var disposalSignal = new TaskCompletionSource<bool>();
+        var sut = new BufferedTransformer<int>(capacity: 4);
+
+        await foreach (var item in sut.TransformAsync(InfiniteSource(disposalSignal)))
+        {
+            if (item >= 5)
+            {
+                break;
+            }
+        }
+
+        // After consumer breaks, the iterator's finally must cancel the producer, which
+        // in turn disposes the source enumerator. This must happen quickly - well under
+        // a generous timeout.
+        var disposed = await Task.WhenAny
+        (
+            disposalSignal.Task,
+            Task.Delay(TimeSpan.FromSeconds(5))
+        ) == disposalSignal.Task;
+
+        Assert.True(disposed, "Source enumerator was not disposed within 5s after consumer abandonment");
+    }
+
+
+
+    // ---------- external cancellation propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_external_cancellation_via_WithCancellation_stops_producer()
+    {
+        var disposalSignal = new TaskCompletionSource<bool>();
+        var sut = new BufferedTransformer<int>(capacity: 4);
+        using var cts = new CancellationTokenSource();
+        var consumed = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.TransformAsync(InfiniteSource(disposalSignal)).WithCancellation(cts.Token))
+                {
+                    consumed++;
+                    if (consumed == 5)
+                    {
+                        cts.Cancel();
+                    }
+                }
+            }
+        );
+
+        // Producer should have been signaled and the source enumerator disposed.
+        var disposed = await Task.WhenAny
+        (
+            disposalSignal.Task,
+            Task.Delay(TimeSpan.FromSeconds(5))
+        ) == disposalSignal.Task;
+
+        Assert.True(disposed, "Source enumerator was not disposed within 5s after external cancellation");
+        Assert.True(consumed >= 5);
+    }
+
+
+
+    // ---------- pre-cancelled external token ----------
+
+    [Fact]
+    public async Task TransformAsync_when_external_token_is_pre_cancelled_throws_OperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var sut = new BufferedTransformer<int>(capacity: 4);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })).WithCancellation(cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    // ---------- backpressure sanity ----------
+
+    [Fact]
+    public async Task TransformAsync_buffer_does_not_grow_beyond_capacity()
+    {
+        // Track in-flight items: produced - consumed. With capacity N the in-flight count
+        // must never exceed N + 1 (the +1 covers the item the producer just took off the
+        // buffer to write next).
+        var capacity = 8;
+        var produced = 0;
+        var consumed = 0;
+        var maxInFlight = 0;
+        var sut = new BufferedTransformer<int>(capacity);
+
+        await foreach (var _ in sut.TransformAsync(TrackedSource(50, () => Interlocked.Increment(ref produced))))
+        {
+            Interlocked.Increment(ref consumed);
+            var inFlight = produced - consumed;
+            if (inFlight > maxInFlight)
+            {
+                maxInFlight = inFlight;
+            }
+        }
+
+        Assert.Equal(50, consumed);
+        // Buffer capacity is the contract; allow a small slack for the in-flight item
+        // sitting between the source's yield and the channel write.
+        Assert.True(maxInFlight <= capacity + 2,
+            $"Max in-flight items {maxInFlight} exceeded capacity+2 ({capacity + 2})");
+
+        static async IAsyncEnumerable<int> TrackedSource(int count, Action onYield)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                onYield();
+                yield return i;
+                await Task.Yield();
+            }
+        }
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void BufferedTransformer_implements_ITransformAsync()
+    {
+        var sut = new BufferedTransformer<int>(capacity: 1);
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    /// <summary>
+    /// An infinite source that signals via the supplied <see cref="TaskCompletionSource{TResult}"/>
+    /// when its iterator is disposed - used to verify the BufferedTransformer cleans up the
+    /// upstream when the consumer abandons or cancels.
+    /// </summary>
+    private static async IAsyncEnumerable<int> InfiniteSource(TaskCompletionSource<bool> disposalSignal)
+    {
+        var i = 0;
+        try
+        {
+            while (true)
+            {
+                await Task.Yield();
+                yield return i++;
+            }
+        }
+        finally
+        {
+            disposalSignal.TrySetResult(true);
+        }
+    }
+
+
+
+    private sealed class Box
+    {
+        public Box(int value)
+        {
+            Value = value;
+        }
+
+
+
+        public int Value { get; }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `BufferedTransformer<T>` per the design discussion and open questions in #9. Standalone, single type parameter, lightweight (`ITransformAsync<T, T>` only).

Stacked on `feature/linq-transformers` (PR #10). Retarget to `dev` once #10 merges. Closes #9 once merged.

## Design built up step by step (see commit message for full notes)

1. **Bare minimum** — channel + producer task + consumer foreach. Identifies three real problems:
2. **Producer error propagation** — wrap producer in try/catch; surface exceptions via `channel.Writer.TryComplete(ex)`. Consumer sees the original exception (unwrapped) once buffered items drain.
3. **Consumer abandonment + external cancellation** — single fix using `[EnumeratorCancellation]` on the private iterator + linked `CancellationTokenSource`. Iterator's try/finally guarantees the producer task is cancelled and awaited before the iterator returns. External `.WithCancellation(token)` propagates through the linked CTS without us adding a `CancellationToken` parameter to the public API.
4. **Polish** — null items check, capacity validation (`>= 1`), channel options (`SingleReader`/`SingleWriter`/`Wait`), VSTHRD103 fix (`CancelAsync` on net8+), method-length split via `PumpAsync` helper.

## API

```csharp
public sealed class BufferedTransformer<T> : ITransformAsync<T, T>
    where T : notnull
{
    public BufferedTransformer(int capacity);   // capacity >= 1
    public int Capacity { get; }
    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items);
}
```

## Use example

```csharp
extractor
    .Pipe(new WhereTransformer<Row>(r => r.IsValid))
    .Pipe(new BufferedTransformer<Row>(capacity: 500))   // parallelism boundary
    .Pipe(new SelectTransformer<Row, Record>(Parse))
    .Pipe(loader);
```

## Open questions deferred to follow-ups

- **Default capacity?** Captured as a comment on #9. Likely workload-dependent; suggested benchmark sweep before deciding.
- **`ProgressReportingTransformer<T>` decorator** for users who want progress on lightweight stages — separate future work.

## Implementation notes

- New `System.Threading.Channels` package reference (10.0.5).
- `SuppressTfmSupportBuildWarnings` added to source csproj to quiet TFM-support warnings about Channels 10.x on net5.0/6.0/7.0 (stable API surface).
- Conditional `CancelAsync` (net8+) vs `Cancel` (older TFMs) under `#if`.

## Test plan

- [x] **191 xunit tests pass on net10.0** (175 prior + 16 new BufferedTransformer)
- [x] **191/191 pass on net462**
- [x] **Source builds clean on all 11 source TFMs** (0 warnings, 0 errors)
- [x] **100% line + method coverage** on `BufferedTransformer<T>` (and the other 13 transformers remain at 100%)
- [x] Tests verify: capacity validation, null items, pass-through fidelity, large-source backpressure, reference identity, producer error propagation including already-buffered items, consumer-abandonment cleanup (via TCS-on-disposal source), external cancellation propagation, pre-cancelled token, in-flight bounded by capacity, interface assignability.
- [ ] CI validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)