### PR TITLE
CI: trigger PR checks on PRs targeting dev

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,9 +26,10 @@ env:
   CODECOV_MINIMUM: 90
   
 on:
-  pull_request_target:  # Runs from the main branch, not from PR branch
+  pull_request_target:  # Runs from the target branch, not from PR branch
     branches:
       - main
+      - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Enables the `pr.yaml` workflow to run on PRs targeting `dev`, not only `main`. One-line change.

## Why

PRs #7, #8, #10, #11, and #12 all target either `dev` or an intermediate stacked branch. None of them trigger CI today because `pr.yaml`'s `pull_request_target.branches` list only contains `main`. This defeats the purpose of the `dev` branch as an integration point.

This PR should merge **first**, before any of the stacked transformer PRs, so they can be validated by CI when retargeted to `dev`.

## Change

```diff
 on:
-  pull_request_target:  # Runs from the main branch, not from PR branch
+  pull_request_target:  # Runs from the target branch, not from PR branch
     branches:
       - main
+      - dev
```

## Security model unchanged

- `pull_request_target` still runs from the target branch.
- Protected configuration files (`.editorconfig`, `Directory.Build.props`, `Directory.Build.targets`, `BannedSymbols.txt`, `*.globalconfig`, `*.ruleset`) are still fetched explicitly from `main` regardless of target branch. PRs targeting `dev` cannot bypass analyzers/config settings any more than PRs targeting `main` can.

## Related files

- `release.yaml` triggers on release publish events, not PR events — no change needed.
- `scripts/build-pr.ps1` is the local-dev equivalent script with no branch-awareness — no change needed.

## Test plan

- [ ] Merge this PR.
- [ ] Retarget PR #7 to trigger a run against `dev`; verify CI kicks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)