### PR TITLE
Fix typo in .gitignore Claude Code section header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.env
-n# Claude Code
+# Claude Code
 .claude/
 
 # User-specific files (MonoDevelop/Xamarin Studio)


### PR DESCRIPTION
Strips a stray `n` prefix from the Claude Code section header in `.gitignore` (`n# Claude Code` → `# Claude Code`). Inherited from `repo-template` (fixed there in Chris-Wolfgang/repo-template#314). Cosmetic-only: the typo did not change ignore behavior, but the line was not a recognized comment header.