### PR TITLE
Add three runnable example projects: BasicChain, LinqOps, BufferedPipeline

### DIFF
--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -43,7 +43,11 @@
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj" />
   </Folder>
-  <Folder Name="/examples/" />
+  <Folder Name="/examples/">
+    <Project Path="examples/BasicChain/BasicChain.csproj" />
+    <Project Path="examples/BufferedPipeline/BufferedPipeline.csproj" />
+    <Project Path="examples/LinqOps/LinqOps.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />
   </Folder>

--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/BasicChain/Program.cs
+++ b/examples/BasicChain/Program.cs
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------
+// BasicChain Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates the most common use of Wolfgang.Etl.Transformers:
+// composing two or more transformers into a single ITransformAsync that an
+// extractor and loader can be wired up to.
+//
+// Key concepts covered:
+//   - WhereTransformer<T>           filter by predicate
+//   - SelectTransformer<TS, TD>     project each item
+//   - .Then(...) extension method   chain transformers with full type inference
+//   - ITransformAsync<,> as the unifying contract for any composition
+//
+// The pipeline:
+//
+//   raw line                          (string)
+//      |
+//      |  Where:  drop blank/comment lines
+//      v
+//   raw line                          (string, non-empty)
+//      |
+//      |  Select: parse "id|name|qty|price" into an Order record
+//      v
+//   Order                             (Order)
+//      |
+//      |  Where:  drop orders with quantity <= 0 or price <= 0
+//      v
+//   Order                             (valid Order)
+//
+// Each .Then() returns a new ChainTransformer with full type inference.
+// The end result is a single ITransformAsync<string, Order> that the
+// loader treats as one transformer - it has no idea three separate
+// stages live behind it.
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.Transformers;
+
+// ---------------------------------------------------------------------------
+// Step 1: Sample input data.
+//
+// In a real ETL the source would be a FixedWidthExtractor / DbClient /
+// HTTP source / etc. Here a plain in-memory list keeps the example focused
+// on the transformer composition.
+// ---------------------------------------------------------------------------
+
+var rawLines = new[]
+{
+    "ORD-001|widget|2|9.99",
+    "",                              // blank line - filtered by stage 1
+    "ORD-002|gadget|1|19.99",
+    "# this is a comment",           // comment line - filtered by stage 1
+    "ORD-003|sprocket|0|4.99",       // qty 0 - filtered by stage 3
+    "ORD-004|gizmo|3|14.99",
+    "",
+    "ORD-005|thingamajig|1|-5.00",   // negative price - filtered by stage 3
+    "ORD-006|doohickey|10|0.50",
+};
+
+// ---------------------------------------------------------------------------
+// Step 2: Build the three transformer stages.
+// ---------------------------------------------------------------------------
+
+ITransformAsync<string, string> stripBlanks = new WhereTransformer<string>
+(
+    line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith("#", StringComparison.Ordinal)
+);
+
+ITransformAsync<string, Order> parse = new SelectTransformer<string, Order>(line =>
+{
+    var parts = line.Split('|');
+    return new Order
+    (
+        Id: parts[0],
+        Name: parts[1],
+        Quantity: int.Parse(parts[2], CultureInfo.InvariantCulture),
+        Price: decimal.Parse(parts[3], CultureInfo.InvariantCulture)
+    );
+});
+
+ITransformAsync<Order, Order> keepValid = new WhereTransformer<Order>
+(
+    order => order.Quantity > 0 && order.Price > 0m
+);
+
+// ---------------------------------------------------------------------------
+// Step 3: Compose the three stages with .Then(...) into a single transformer.
+//
+// The C# compiler infers all type parameters from the call:
+//   stripBlanks  : ITransformAsync<string, string>
+//   parse        : ITransformAsync<string, Order>
+//   keepValid    : ITransformAsync<Order, Order>
+//   pipeline     : ITransformAsync<string, Order>
+// ---------------------------------------------------------------------------
+
+var pipeline = stripBlanks
+    .Then(parse)
+    .Then(keepValid);
+
+// ---------------------------------------------------------------------------
+// Step 4: Wire the pipeline between an extractor and a loader.
+//
+// TestExtractor and TestLoader come from Wolfgang.Etl.TestKit and stand in
+// for the real source/sink in production code.
+// ---------------------------------------------------------------------------
+
+var extractor = new TestExtractor<string>(rawLines);
+var loader = new TestLoader<Order>(collectItems: true);
+var token = CancellationToken.None;
+
+await loader.LoadAsync
+(
+    pipeline.TransformAsync(extractor.ExtractAsync(token)),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// Step 5: Inspect the results.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Input lines:");
+foreach (var line in rawLines)
+{
+    Console.WriteLine($"  {(string.IsNullOrEmpty(line) ? "<blank>" : line)}");
+}
+
+Console.WriteLine();
+Console.WriteLine("Valid orders that flowed through the pipeline:");
+Console.WriteLine(new string('-', 60));
+
+foreach (var order in loader.GetCollectedItems()!)
+{
+    Console.WriteLine
+    (
+        $"  {order.Id}  {order.Name,-12}  qty={order.Quantity,2}  price={order.Price,7:0.00}"
+    );
+}
+
+Console.WriteLine(new string('-', 60));
+Console.WriteLine
+(
+    $"In: {rawLines.Length} raw lines  ->  Out: {loader.GetCollectedItems()!.Count} valid orders"
+);
+
+// ---------------------------------------------------------------------------
+// Order - the projected type produced by the pipeline.
+// ---------------------------------------------------------------------------
+
+public sealed record Order(string Id, string Name, int Quantity, decimal Price);

--- a/examples/BufferedPipeline/BufferedPipeline.csproj
+++ b/examples/BufferedPipeline/BufferedPipeline.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/BufferedPipeline/Program.cs
+++ b/examples/BufferedPipeline/Program.cs
@@ -1,0 +1,117 @@
+// ---------------------------------------------------------------------------
+// BufferedPipeline Example
+// ---------------------------------------------------------------------------
+//
+// This example shows why BufferedTransformer<T> exists.
+//
+// With plain IAsyncEnumerable<T> chaining, every stage in the pipeline runs
+// on the same logical call path: the downstream stage's MoveNextAsync drives
+// the upstream stage one item at a time. Throughput is bounded by the
+// SLOWEST stage; fast stages idle while waiting.
+//
+// Inserting a BufferedTransformer<T> between two stages introduces a producer
+// task that drains the upstream into a bounded channel. The downstream stage
+// then reads from the channel. The two sides run CONCURRENTLY, so total
+// throughput approaches MAX(stage speeds) instead of MIN.
+//
+// To make the difference visible we use:
+//
+//   - A SOURCE that simulates I/O latency (e.g. fetching pages from an API)
+//   - A SINK that simulates I/O latency (e.g. writing rows to a database)
+//
+// Without a buffer, those two latencies are SERIAL. With a buffer, they
+// OVERLAP - while the sink is writing item N the source is already
+// fetching item N+1.
+//
+// We measure both runs and print the wall-clock difference.
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Transformers;
+
+const int itemCount = 20;
+const int sourceDelayMs = 25;
+const int sinkDelayMs = 25;
+
+// ---------------------------------------------------------------------------
+// Run 1: NO BUFFER - source and sink are serialized.
+//
+// Approximate wall-clock time:  itemCount * (sourceDelayMs + sinkDelayMs)
+// ---------------------------------------------------------------------------
+
+Console.WriteLine($"Items: {itemCount}    source delay: {sourceDelayMs} ms    sink delay: {sinkDelayMs} ms");
+Console.WriteLine();
+
+Console.WriteLine("Run 1 - no buffer (serial source <-> sink):");
+
+var swSerial = Stopwatch.StartNew();
+await ConsumeAsync(SlowSource(itemCount, sourceDelayMs));
+swSerial.Stop();
+
+var serialMs = swSerial.ElapsedMilliseconds;
+var serialTheoretical = itemCount * (sourceDelayMs + sinkDelayMs);
+Console.WriteLine($"  wall-clock: {serialMs} ms   (theoretical serial: {serialTheoretical} ms)");
+Console.WriteLine();
+
+// ---------------------------------------------------------------------------
+// Run 2: WITH BUFFER - source and sink overlap.
+//
+// Approximate wall-clock time:  itemCount * MAX(sourceDelayMs, sinkDelayMs)
+//                               + small startup cost for the first item
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Run 2 - BufferedTransformer<int>(capacity: 4) between source and sink:");
+
+var buffered = new BufferedTransformer<int>(capacity: 4);
+
+var swBuffered = Stopwatch.StartNew();
+await ConsumeAsync(buffered.TransformAsync(SlowSource(itemCount, sourceDelayMs)));
+swBuffered.Stop();
+
+var bufferedMs = swBuffered.ElapsedMilliseconds;
+var bufferedTheoretical = itemCount * Math.Max(sourceDelayMs, sinkDelayMs);
+Console.WriteLine($"  wall-clock: {bufferedMs} ms   (theoretical max-bound: {bufferedTheoretical} ms)");
+Console.WriteLine();
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+var speedup = serialMs / (double)Math.Max(1, bufferedMs);
+Console.WriteLine(new string('-', 60));
+Console.WriteLine($"Speedup with BufferedTransformer: {speedup.ToString("0.00", CultureInfo.InvariantCulture)}x");
+Console.WriteLine();
+Console.WriteLine("With equal source and sink delays, theoretical max speedup is 2x.");
+Console.WriteLine("Real speedup is slightly less because the channel and producer-task");
+Console.WriteLine("scheduling add a small constant overhead.");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Simulates an I/O-bound source - each MoveNextAsync waits 'delayMs'
+// before yielding the next integer.
+static async IAsyncEnumerable<int> SlowSource(int count, int delayMs)
+{
+    for (var i = 0; i < count; i++)
+    {
+        await Task.Delay(delayMs).ConfigureAwait(false);
+        yield return i;
+    }
+}
+
+// Simulates an I/O-bound sink - each iteration of the loop body waits
+// 'sinkDelayMs' before "writing" the item. We just await the delay; the
+// actual item is unused for this measurement.
+static async Task ConsumeAsync(IAsyncEnumerable<int> items)
+{
+    await foreach (var _ in items.ConfigureAwait(false))
+    {
+        await Task.Delay(sinkDelayMs).ConfigureAwait(false);
+    }
+}

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!--
+    Relaxed analyzer rules for example projects.
+    Examples use top-level statements with helper types in Program.cs,
+    which triggers MA0048 (file name must match type name) and
+    S3903 (type must be in a namespace). CA2007 (ConfigureAwait) is
+    not meaningful in console apps.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);MA0048;S3903;CA2007</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/LinqOps/Program.cs
+++ b/examples/LinqOps/Program.cs
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------------
+// LinqOps Example
+// ---------------------------------------------------------------------------
+//
+// This example tours the LINQ-style transformers in Wolfgang.Etl.Transformers.
+// Each is a standalone ITransformAsync<,> that mirrors a familiar LINQ
+// operator. They compose with .Then(...) into a single transformer.
+//
+// The pipeline:
+//
+//   raw integers (with duplicates)
+//      |
+//      |  Where:    keep evens
+//      v
+//   even integers
+//      |
+//      |  Distinct: drop repeats
+//      v
+//   distinct evens
+//      |
+//      |  Select:   project to a richer record
+//      v
+//   Bucket records
+//      |
+//      |  Take:     first N (windowing)
+//      v
+//   first N Bucket records
+//      |
+//      |  Chunk:    group into arrays of size 3
+//      v
+//   Bucket[]   (one or more arrays, last may be partial)
+//
+// Each stage is a standalone transformer. The chain composes them with
+// full type inference at every .Then(...).
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.Transformers;
+
+// ---------------------------------------------------------------------------
+// Source: 1..30, with a few intentional duplicates so Distinct has work to do.
+// ---------------------------------------------------------------------------
+
+var source = Enumerable.Range(1, 30)
+    .Concat(new[] { 4, 8, 12, 16, 20 })   // duplicates to be deduped
+    .ToArray();
+
+// ---------------------------------------------------------------------------
+// Build the chain.
+//
+// Notes on each transformer:
+//
+//   WhereTransformer<T>        : ITransformAsync<T, T>
+//                                Sync OR async predicate via two ctors.
+//
+//   DistinctTransformer<T>     : ITransformAsync<T, T>
+//                                Default- or custom-comparer ctor.
+//                                Memory grows with unique-item count.
+//
+//   SelectTransformer<TS, TD>  : ITransformAsync<TS, TD>
+//                                Sync OR async selector via two ctors.
+//
+//   TakeTransformer<T>         : ITransformAsync<T, T>
+//                                Negative/zero count yields empty without
+//                                enumerating the source.
+//
+//   ChunkTransformer<T>        : ITransformAsync<T, T[]>
+//                                Last chunk may be smaller than 'size'.
+//                                Each yielded chunk is a fresh array.
+// ---------------------------------------------------------------------------
+
+var pipeline = new WhereTransformer<int>(i => i % 2 == 0)
+    .Then(new DistinctTransformer<int>())
+    .Then(new SelectTransformer<int, Bucket>(i => new Bucket(i, $"item-{i:D3}")))
+    .Then(new TakeTransformer<Bucket>(count: 8))
+    .Then(new ChunkTransformer<Bucket>(size: 3));
+
+// ---------------------------------------------------------------------------
+// Wire the pipeline between TestKit endpoints.
+// ---------------------------------------------------------------------------
+
+var extractor = new TestExtractor<int>(source);
+var loader = new TestLoader<Bucket[]>(collectItems: true);
+var token = CancellationToken.None;
+
+await loader.LoadAsync
+(
+    pipeline.TransformAsync(extractor.ExtractAsync(token)),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// Show what each stage did.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Source ({0} items, with duplicates):", source.Length);
+Console.WriteLine("  " + string.Join(", ", source.Select(i => i.ToString(CultureInfo.InvariantCulture))));
+Console.WriteLine();
+
+Console.WriteLine("After Where(even) + Distinct + Select(Bucket) + Take(8) + Chunk(3):");
+Console.WriteLine(new string('-', 70));
+
+var chunkIndex = 0;
+foreach (var chunk in loader.GetCollectedItems()!)
+{
+    chunkIndex++;
+    var rendered = string.Join(", ", chunk.Select(b => $"({b.Number},{b.Label})"));
+    Console.WriteLine($"  chunk #{chunkIndex} ({chunk.Length} item{(chunk.Length == 1 ? string.Empty : "s")}):  {rendered}");
+}
+
+Console.WriteLine(new string('-', 70));
+var chunks = loader.GetCollectedItems()!;
+Console.WriteLine($"Total chunks emitted: {chunks.Count}");
+Console.WriteLine($"Total Bucket items:   {chunks.Sum(c => c.Length)}");
+
+// ---------------------------------------------------------------------------
+// Bucket - intermediate record type produced by the Select stage.
+// ---------------------------------------------------------------------------
+
+public sealed record Bucket(int Number, string Label);


### PR DESCRIPTION
## Summary

The \`examples/\` folder was empty. This adds three console programs that demonstrate the most common ways to use Wolfgang.Etl.Transformers — modelled on the ETL-Fixed Width examples convention.

Closes the example-folder-empty item from the post-merge backlog.

## Examples added

### \`examples/BasicChain\`
Fundamental composition. \`WhereTransformer\` + \`SelectTransformer\` + \`WhereTransformer\` chained via \`.Then()\` into a single \`ITransformAsync<string, Order>\` that the loader treats as one transformer. Filters blank/comment lines, parses \`"id|name|qty|price"\`, drops invalid orders.

### \`examples/LinqOps\`
Tour of the LINQ-style transformers. \`Where(even) → Distinct → Select(project) → Take(8) → Chunk(3)\`. Output rendered chunk-by-chunk.

### \`examples/BufferedPipeline\`
Demonstrates *why* \`BufferedTransformer<T>\` exists. Slow source + slow sink with equal per-item delay (25 ms each, 20 items). Run 1 has no buffer (serialized), Run 2 inserts a \`BufferedTransformer<int>(capacity: 4)\` between them (overlapped). Prints wall-clock time for each and the resulting speedup. **Observed ~1.88× vs the 2× theoretical max** — the gap is channel/producer-task scheduling overhead, called out in the example's footer.

## Convention

- Top-level statements with heavy comment headers
- \`ProjectReference\` to the source library
- \`Wolfgang.Etl.TestKit\` 0.8.0 for \`TestExtractor\` / \`TestLoader\` endpoints (BufferedPipeline doesn't need TestKit since it's measuring timing not testing)
- \`examples/Directory.Build.props\` relaxes \`MA0048;S3903;CA2007\` for top-level Program.cs files (matches the ETL-Fixed Width convention)

## Test plan

- [x] All three projects build clean (0 warnings, 0 errors)
- [x] BasicChain runs end-to-end and prints expected filtered/parsed orders (4 valid out of 9 input lines)
- [x] LinqOps runs and produces 3 chunks (3, 3, 2 items) from 35 source items with duplicates
- [x] BufferedPipeline runs and shows ~1.88× speedup
- [x] \`ETL-Transformers.slnx\` updated to include all three projects under \`/examples/\`
- [ ] CI validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)