### PR TITLE
Fill README placeholders and fix Target Frameworks table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wolfgang.Etl.Transformers
 
-A collection generic transformers for use in ETLs using Wolfgang.Etl.Abstractions
+A collection of generic, broadly reusable transformers for use in ETL pipelines built on [Wolfgang.Etl.Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
@@ -35,25 +35,93 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ## 🚀 Quick Start
 
-{{QUICK_START_EXAMPLE}}
+Compose any number of transformers into a single pipeline with `.Then(...)`:
+
+```csharp
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Transformers;
+
+// Three small, single-purpose transformers...
+ITransformAsync<string, string> stripBlanks = new WhereTransformer<string>
+(
+    line => !string.IsNullOrWhiteSpace(line)
+);
+
+ITransformAsync<string, Order> parse = new SelectTransformer<string, Order>
+(
+    line => Order.Parse(line)
+);
+
+ITransformAsync<Order, Order> keepValid = new WhereTransformer<Order>
+(
+    o => o.Quantity > 0 && o.Price > 0m
+);
+
+// ...composed into one with full type inference at every .Then(...).
+var pipeline = stripBlanks.Then(parse).Then(keepValid);
+// pipeline : ITransformAsync<string, Order>
+
+// Wire it between an extractor and a loader (TestKit doubles shown for brevity).
+await loader.LoadAsync
+(
+    pipeline.TransformAsync(extractor.ExtractAsync(token)),
+    token
+);
+```
+
+Each transformer is a small `sealed` class implementing `ITransformAsync<,>` directly. No base-class inheritance, no per-item allocations, no surprises.
 
 ---
 
 ## ✨ Features
 
-{{FEATURES_TABLE}}
+| Transformer | Purpose |
+|---|---|
+| **`PassThroughTransformer<T>`** | Yields each item unchanged. Useful as a placeholder, DI default, or test seam. Implements `ITransformWithCancellationAsync<T, T>`. |
+| **`SelectTransformer<TSource, TDestination>`** | LINQ `Select` — projects each item via a sync or async selector. |
+| **`WhereTransformer<T>`** | LINQ `Where` — filters items by sync or async predicate. |
+| **`SelectManyTransformer<TSource, TDestination>`** | LINQ `SelectMany` — flattens a one-to-many projection (sync `IEnumerable<T>` or async `IAsyncEnumerable<T>` selector). |
+| **`OfTypeTransformer<TSource, TDestination>`** | LINQ `OfType` — silently filters items that are not of the destination type. |
+| **`CastTransformer<TSource, TDestination>`** | LINQ `Cast` — casts every item; throws `InvalidCastException` on mismatch. |
+| **`TakeTransformer<T>`** | LINQ `Take(int)` — yields up to N items, then stops without enumerating further. |
+| **`TakeWhileTransformer<T>`** | LINQ `TakeWhile` — yields items until the predicate first returns false. |
+| **`SkipTransformer<T>`** | LINQ `Skip(int)` — discards the first N items. Returns the source directly when `count <= 0`. |
+| **`SkipWhileTransformer<T>`** | LINQ `SkipWhile` — skips items while the predicate is true; predicate stops being called once it first returns false. |
+| **`DistinctTransformer<T>`** | LINQ `Distinct` — yields each unique item, optional `IEqualityComparer<T>`. |
+| **`DistinctByTransformer<TSource, TKey>`** | LINQ `DistinctBy` — yields each item with a unique key as projected by a sync key selector. |
+| **`ChunkTransformer<T>`** | LINQ `Chunk(int)` — batches the input into right-sized `T[]` arrays. Last chunk may be smaller. |
+| **`BufferedTransformer<T>`** | Decouples upstream and downstream stages via a bounded `System.Threading.Channels.Channel<T>` — enables pipeline parallelism, throughput approaches `max(stage speeds)` instead of `min`. |
+| **`ChainTransformer<TSource, TIntermediate, TDestination>`** | Composes two transformers into one. Build any-N pipelines via the `.Then(...)` extension. |
+| **`ChainTransformerWithCancellation<TSource, TIntermediate, TDestination>`** | Same as `ChainTransformer`, but for two `ITransformWithCancellationAsync<,>` transformers — propagates a single `CancellationToken` to both stages. |
+| **`TransformerExtensions.Then(...)`** | Extension on `ITransformAsync<,>` (and a more-specific overload on `ITransformWithCancellationAsync<,>`) that composes two transformers into a single one with full type inference. Chain N stages by chaining `.Then(...).Then(...)`. |
+
+### Design notes
+
+- **Lightweight by design.** Every transformer implements `ITransformAsync<,>` (or `ITransformWithCancellationAsync<,>`) directly — none inherit from `TransformerBase<,,>`. Benchmarks in [`benchmarks/`](benchmarks/) measured a 14–27% throughput cost from the base class and motivated the lightweight design across the library.
+- **`sealed` everywhere.** No virtual dispatch in the hot loop.
+- **Sync + async lambdas.** Transformers that take a predicate or selector ship two constructors — sync `Func<...>` and async `Func<..., ValueTask<...>>` — with separate private iterator methods, so the hot loop never branches on which kind of lambda was supplied.
+- **No progress, no Skip/Max counters.** Compose with dedicated transformers (`SkipTransformer`, `TakeTransformer`, future `ProgressReportingTransformer`) when those concerns are needed.
 
 **Examples:**
-{{FEATURE_EXAMPLES}}
+
+The [`examples/`](examples/) folder contains runnable console projects for the most common scenarios:
+
+| Example | Description |
+|---|---|
+| [BasicChain](examples/BasicChain) | Three transformers (`Where → Select → Where`) composed via `.Then(...)` into a single `ITransformAsync<string, Order>`. |
+| [LinqOps](examples/LinqOps) | Tour of the LINQ-style transformers: `Where → Distinct → Select → Take → Chunk` in one chain. |
+| [BufferedPipeline](examples/BufferedPipeline) | Demonstrates *why* `BufferedTransformer<T>` exists. Slow source + slow sink with and without a buffer; prints wall-clock comparison and observed speedup. |
 
 ---
 
 ## 🎯 Target Frameworks
 
+The source library targets the same TFM set as `Wolfgang.Etl.Abstractions` 0.12.0:
+
 | Framework | Versions |
 |-----------|----------|
-| .NET Framework | .NET 4.6.2, .NET 4.7.0, .NET 4.7.1, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
-| .NET Core | .NET Core 3.1 |
+| .NET Framework | .NET 4.6.2, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
+| .NET Standard | .NET Standard 2.0 |
 | .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
 
 ---
@@ -177,5 +245,8 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## 🙏 Acknowledgments
 
-{{ACKNOWLEDGMENTS}}
+- **[Wolfgang.Etl.Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions)** — provides the `ITransformAsync<,>` and `ITransformWithCancellationAsync<,>` interfaces (plus `TransformerBase<,,>`, which the lightweight transformers in this library deliberately do not inherit from). Sets the `Microsoft.Bcl.AsyncInterfaces` floor for older TFMs.
+- **[Wolfgang.Etl.TestKit](https://github.com/Chris-Wolfgang/ETL-TestKit)** — `TestExtractor<T>` and `TestLoader<T>` used by the example projects as in-memory pipeline endpoints.
+- **[System.Threading.Channels](https://www.nuget.org/packages/System.Threading.Channels)** — bounded channel powering `BufferedTransformer<T>` for pipeline parallelism.
+- **[BenchmarkDotNet](https://benchmarkdotnet.org/)** — used in [`benchmarks/`](benchmarks/) to compare the lightweight `WhereTransformer` against a `TransformerBase`-backed alternative; the resulting 14–27% throughput delta motivated the lightweight design across the library.
 


### PR DESCRIPTION
## Summary

The README had four unfilled mustache placeholders inherited from the template, plus a typo in the tagline and an incorrect Target Frameworks table. Now contains real content that reflects what the library actually does.

Stacked on PR #27 (\`feature/examples\`) because the \"FEATURE_EXAMPLES\" section links to the three example projects added in that PR. Retarget to \`dev\` once #27 merges.

## Changes

### Placeholders filled

- **\`{{QUICK_START_EXAMPLE}}\`** — ~30-line snippet showing three single-purpose transformers (\`WhereTransformer\` + \`SelectTransformer\` + \`WhereTransformer\`) composed via \`.Then(...)\` into a single \`ITransformAsync<string, Order>\` and wired between TestKit endpoints.
- **\`{{FEATURES_TABLE}}\`** — 17-row table covering every public type in the library (15 transformers + 2 extension overloads), each with a one-line purpose. Followed by a \"Design notes\" section that captures the lightweight pattern, sealed-everywhere choice, sync+async lambda convention, and \"no progress / no Skip-Max counters\" rationale.
- **\`{{FEATURE_EXAMPLES}}\`** — links to \`examples/BasicChain\`, \`examples/LinqOps\`, \`examples/BufferedPipeline\` with one-line summaries.
- **\`{{ACKNOWLEDGMENTS}}\`** — \`Wolfgang.Etl.Abstractions\`, \`Wolfgang.Etl.TestKit\`, \`System.Threading.Channels\`, \`BenchmarkDotNet\`.

### Other fixes

- **Tagline typo** — \"collection generic transformers\" → \"collection of generic, broadly reusable transformers... built on Wolfgang.Etl.Abstractions\" (with link).
- **Target Frameworks table** — previously listed .NET 4.7, 4.7.1, and .NET Core 3.1, none of which the library targets. Corrected to match the actual csproj: \`net462; net472; net48; net481; netstandard2.0; net5.0 — net10.0\`. Note added that this matches Abstractions 0.12.0.

## Verification

- [x] No remaining \`{{...}}\` placeholders in README.md
- [x] Target Frameworks table matches \`src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj\`
- [x] Example links resolve to projects added in PR #27
- [ ] CI validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)