### PR TITLE
Add Stryker mutation-testing workflow (T3)

### DIFF
--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -24,14 +24,23 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect stryker-config.json
         id: check
         shell: bash
         run: |
+          # Explicit existence checks rather than globbing — `nullglob` only
+          # drops words that look like patterns (contain *, ?, [). The bare
+          # literal `stryker-config.json` has no glob characters, so it would
+          # be preserved as a literal even when the file doesn't exist, and
+          # the workflow would mistakenly think a config was present.
           shopt -s globstar nullglob
-          configs=(stryker-config.json tests/**/stryker-config.json)
+          configs=()
+          [ -f stryker-config.json ] && configs+=(stryker-config.json)
+          for cfg in tests/**/stryker-config.json; do
+            [ -f "$cfg" ] && configs+=("$cfg")
+          done
           if (( ${#configs[@]} )); then
             printf 'found=true\n' >> "$GITHUB_OUTPUT"
             printf 'configs<<EOF\n%s\nEOF\n' "${configs[*]}" >> "$GITHUB_OUTPUT"
@@ -42,7 +51,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,0 +1,80 @@
+# Stryker mutation testing
+#
+# Runs the Stryker.NET mutation tester against the repo's test projects to
+# measure mutation score. Mutation runs are slow — triggered manually
+# (workflow_dispatch) and on a weekly schedule, not on every PR.
+#
+# The workflow looks for a stryker-config.json at the repo root or under
+# tests/**/. If none is present the run is a no-op (Stryker setup is a
+# per-repo follow-up; this file is the canonical infrastructure).
+name: Stryker (mutation testing)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Run Stryker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Detect stryker-config.json
+        id: check
+        shell: bash
+        run: |
+          shopt -s globstar nullglob
+          configs=(stryker-config.json tests/**/stryker-config.json)
+          if (( ${#configs[@]} )); then
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            printf 'configs<<EOF\n%s\nEOF\n' "${configs[*]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
+            printf 'found=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-stryker
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool install -g dotnet-stryker
+
+      - name: Run Stryker
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          if [ -f stryker-config.json ]; then
+            dotnet stryker --config-file stryker-config.json
+          else
+            for cfg in tests/**/stryker-config.json; do
+              dir=$(dirname "$cfg")
+              echo "::group::Stryker in $dir"
+              (cd "$dir" && dotnet stryker)
+              echo "::endgroup::"
+            done
+          fi
+
+      - name: Upload Stryker report
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: |
+            **/StrykerOutput/**
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds `.github/workflows/stryker.yaml` — canonical Stryker.NET mutation-testing workflow.

- Triggers on `workflow_dispatch` and a weekly Sunday schedule (mutation runs are slow — not on every PR).
- Detects `stryker-config.json` at repo root or under `tests/**/`. If none present, the run is a no-op and logs a notice. Per-repo Stryker config is a follow-up; this PR is the canonical infrastructure.
- Uploads the StrykerOutput report as a 30-day artifact.

## Why this is a protected PR

`.github/workflows/*` trips the `pr.yaml` Detect .NET Projects guard, so this PR needs a maintainer admin bypass. It is kept minimal — one new workflow file, no behavior change to existing CI.

Initiative T3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)