### PR TITLE
feat: IAsyncEnumerable<T>.Buffered(int) extension method

### DIFF
--- a/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Wolfgang.Etl.Abstractions;
 
 
@@ -6,11 +7,53 @@ using Wolfgang.Etl.Abstractions;
 namespace Wolfgang.Etl.Transformers;
 
 /// <summary>
-/// Extension methods on <see cref="ITransformAsync{TSource, TDestination}"/> that compose
-/// transformers into larger units.
+/// Extension methods that compose transformers and wrap sequences with pipeline infrastructure.
 /// </summary>
 public static class TransformerExtensions
 {
+    /// <summary>
+    /// Inserts a <see cref="BufferedTransformer{T}"/> into a sequence, decoupling the upstream
+    /// producer from the downstream consumer so both stages can run concurrently.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the sequence. Must be non-null.</typeparam>
+    /// <param name="source">The source sequence to buffer. Must not be <see langword="null"/>.</param>
+    /// <param name="capacity">
+    /// The maximum number of items the internal buffer holds. Must be at least 1.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IAsyncEnumerable{T}"/> containing the same items as <paramref name="source"/>,
+    /// in the same order, but produced concurrently with consumption.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 1.</exception>
+    /// <remarks>
+    /// <para>
+    /// Sugar for <c>new <see cref="BufferedTransformer{T}"/>(capacity).TransformAsync(source)</c>.
+    /// See <see cref="BufferedTransformer{T}"/> for a full description of the buffering semantics,
+    /// cancellation handling, and error propagation.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    ///     var results = await extractor
+    ///         .ExtractAsync(token)
+    ///         .Buffered(capacity: 500)
+    ///         .SelectAsync(Parse)
+    ///         .ToListAsync();
+    /// </code>
+    /// </example>
+    public static IAsyncEnumerable<T> Buffered<T>
+    (
+        this IAsyncEnumerable<T> source,
+        int capacity
+    )
+        where T : notnull
+    {
+        return new BufferedTransformer<T>(capacity).TransformAsync(source);
+    }
+
+
+
     /// <summary>
     /// Composes two transformers into a single one: items flow through <paramref name="first"/>,
     /// then through <paramref name="next"/>. Equivalent to constructing

--- a/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
@@ -49,6 +49,15 @@ public static class TransformerExtensions
     )
         where T : notnull
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(source);
+#else
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+#endif
+
         return new BufferedTransformer<T>(capacity).TransformAsync(source);
     }
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
@@ -248,6 +249,116 @@ public class TransformerExtensionsTests
         );
 
         Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    // ---------- Buffered — null / range guards ----------
+
+    [Fact]
+    public void Buffered_when_source_is_null_throws_ArgumentNullException()
+    {
+        IAsyncEnumerable<int> source = null!;
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => source.Buffered(capacity: 1)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Buffered_when_capacity_is_zero_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => ToAsync(new[] { 1, 2, 3 }).Buffered(capacity: 0)
+        );
+
+        Assert.Equal("capacity", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Buffered_when_capacity_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => ToAsync(new[] { 1, 2, 3 }).Buffered(capacity: -1)
+        );
+
+        Assert.Equal("capacity", ex.ParamName);
+    }
+
+
+
+    // ---------- Buffered — functional ----------
+
+    [Fact]
+    public async Task Buffered_yields_same_items_in_same_order()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = await CollectAsync(ToAsync(source).Buffered(capacity: 2));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task Buffered_when_source_is_empty_yields_empty_sequence()
+    {
+        var result = await CollectAsync(ToAsync(Array.Empty<int>()).Buffered(capacity: 8));
+
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task Buffered_with_capacity_1_yields_all_items()
+    {
+        var source = new[] { 10, 20, 30 };
+
+        var result = await CollectAsync(ToAsync(source).Buffered(capacity: 1));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task Buffered_with_large_capacity_yields_all_items()
+    {
+        var source = Enumerable.Range(1, 500).ToArray();
+
+        var result = await CollectAsync(ToAsync(source).Buffered(capacity: 8192));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task Buffered_cancellation_stops_enumeration()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in ToAsync(Enumerable.Range(1, 1000)).Buffered(capacity: 4).WithCancellation(cts.Token))
+                {
+                }
+            }
+        );
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
@@ -265,7 +265,7 @@ public class TransformerExtensionsTests
             () => source.Buffered(capacity: 1)
         );
 
-        Assert.Equal("items", ex.ParamName);
+        Assert.Equal("source", ex.ParamName);
     }
 
 


### PR DESCRIPTION
## Summary

Adds a `.Buffered(int capacity)` extension method on `IAsyncEnumerable<T>` — sugar for constructing a `BufferedTransformer<T>` and calling `TransformAsync` inline.

Before:
```csharp
var buffered = new BufferedTransformer<Row>(capacity: 500).TransformAsync(source);
```

After:
```csharp
var buffered = source.Buffered(capacity: 500);
```

Or inline in a chain:
```csharp
extractor.ExtractAsync(token)
    .Buffered(500)
    .Pipe(formatter)
    .Pipe(loader);
```

## Changes

- `TransformerExtensions.cs` — added `Buffered<T>(this IAsyncEnumerable<T> source, int capacity)` with full XML doc; updated class summary from `ITransformAsync`-only to reflect broader surface
- `TransformerExtensionsTests.cs` — 8 new tests: null guard, capacity-zero guard, capacity-negative guard, same-order, empty source, capacity-1, large-capacity, cancellation

## Test results

- 21/21 on `net10.0`
- 21/21 on `net462`

🤖 Generated with [Claude Code](https://claude.com/claude-code)