### PR TITLE
feat: ProgressReportingTransformer<T> decorator

### DIFF
--- a/src/Wolfgang.Etl.Transformers/ProgressReportingTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ProgressReportingTransformer.cs
@@ -62,10 +62,14 @@ public sealed class ProgressReportingTransformer<T> : ITransformAsync<T, T>
     /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
     public ProgressReportingTransformer(Action<T> callback)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(callback);
+#else
         if (callback == null)
         {
             throw new ArgumentNullException(nameof(callback));
         }
+#endif
 
         _syncCallback = callback;
     }
@@ -82,10 +86,14 @@ public sealed class ProgressReportingTransformer<T> : ITransformAsync<T, T>
     /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
     public ProgressReportingTransformer(Func<T, ValueTask> callback)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(callback);
+#else
         if (callback == null)
         {
             throw new ArgumentNullException(nameof(callback));
         }
+#endif
 
         _asyncCallback = callback;
     }

--- a/src/Wolfgang.Etl.Transformers/ProgressReportingTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ProgressReportingTransformer.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// A decorator transformer that calls a user-supplied callback for each item as it passes
+/// through, then yields the item unchanged. Useful for reporting progress, logging, or
+/// collecting metrics on any stage in a composed pipeline.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="ProgressReportingTransformer{T}"/> is a pure pass-through: it does not filter,
+/// project, or reorder items. The callback is the only observable side-effect.
+/// </para>
+/// <para>
+/// Insert it between any two stages in a chain to observe items at that point:
+/// </para>
+/// <code>
+///     long count = 0;
+///     var reporter = new ProgressReportingTransformer&lt;Order&gt;(item =&gt;
+///         myProgress.Report(Interlocked.Increment(ref count)));
+///
+///     var pipeline = parse
+///         .Then(reporter)       // taps the stream after parsing
+///         .Then(validate);
+/// </code>
+/// <para>
+/// Because it implements <see cref="ITransformAsync{TSource, TDestination}"/>, it composes
+/// naturally with <see cref="TransformerExtensions"/>.
+/// </para>
+/// <para>
+/// Callbacks are invoked on the caller's thread (or task) for each item before it is yielded
+/// to the downstream stage. Long-running synchronous callbacks will block the pipeline; use the
+/// async overload if the callback itself performs I/O.
+/// </para>
+/// <para>
+/// Exceptions thrown by the callback propagate to the consumer through the normal
+/// <see cref="IAsyncEnumerable{T}"/> pull contract.
+/// </para>
+/// </remarks>
+public sealed class ProgressReportingTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly Action<T>?            _syncCallback;
+    private readonly Func<T, ValueTask>?   _asyncCallback;
+
+
+
+    /// <summary>
+    /// Initializes a new instance that invokes a synchronous callback for each item.
+    /// </summary>
+    /// <param name="callback">
+    /// The action to invoke for each item before it is yielded downstream.
+    /// Must not be <see langword="null"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
+    public ProgressReportingTransformer(Action<T> callback)
+    {
+        if (callback == null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        _syncCallback = callback;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance that invokes an asynchronous callback for each item.
+    /// </summary>
+    /// <param name="callback">
+    /// The async function to await for each item before it is yielded downstream.
+    /// Must not be <see langword="null"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
+    public ProgressReportingTransformer(Func<T, ValueTask> callback)
+    {
+        if (callback == null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        _asyncCallback = callback;
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/>, invoking the callback
+    /// once per item before yielding it downstream.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>
+    /// An asynchronous sequence containing the same items as <paramref name="items"/>, in the
+    /// same order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140 // Roslynator does not associate throw inside #else block with method XML doc
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+
+        return _asyncCallback != null
+            ? ReportAsync(items, _asyncCallback)
+            : ReportSync(items, _syncCallback!);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> ReportSync(IAsyncEnumerable<T> items, Action<T> callback)
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            callback(item);
+            yield return item;
+        }
+    }
+
+
+
+    private static async IAsyncEnumerable<T> ReportAsync(IAsyncEnumerable<T> items, Func<T, ValueTask> callback)
+    {
+        await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
+        {
+            await callback(item).ConfigureAwait(continueOnCapturedContext: false);
+            yield return item;
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+public class ProgressReportingTransformerTests
+{
+    // ---------- construction ----------
+
+    [Fact]
+    public void Ctor_with_sync_callback_when_callback_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new ProgressReportingTransformer<int>((Action<int>)null!)
+        );
+
+        Assert.Equal("callback", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Ctor_with_async_callback_when_callback_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new ProgressReportingTransformer<int>((Func<int, ValueTask>)null!)
+        );
+
+        Assert.Equal("callback", ex.ParamName);
+    }
+
+
+
+    // ---------- null input ----------
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => { });
+
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => sut.TransformAsync(null!)
+        );
+
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    // ---------- sync callback — pass-through ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_yields_all_items_unchanged()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => { });
+        var source = new[] { 10, 20, 30 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_preserves_order()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => { });
+        var source = new[] { 3, 1, 4, 1, 5, 9, 2, 6 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_when_source_is_empty_yields_no_items()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => { });
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- sync callback — callback invocations ----------
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_is_called_once_per_item()
+    {
+        var seen = new List<int>();
+        var sut  = new ProgressReportingTransformer<int>(i => seen.Add(i));
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, seen);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_not_called_when_source_is_empty()
+    {
+        var callCount = 0;
+        var sut = new ProgressReportingTransformer<int>(_ => callCount++);
+
+        await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Equal(0, callCount);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_receives_items_in_source_order()
+    {
+        var received = new List<int>();
+        var sut      = new ProgressReportingTransformer<int>(i => received.Add(i));
+        var source   = new[] { 100, 200, 300 };
+
+        await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, received);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_sync_callback_can_be_used_to_count_items()
+    {
+        var count = 0;
+        var sut   = new ProgressReportingTransformer<int>(_ => count++);
+        var source = new[] { 1, 2, 3, 4, 5, 6, 7 };
+
+        await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(7, count);
+    }
+
+
+
+    // ---------- async callback — pass-through ----------
+
+    [Fact]
+    public async Task TransformAsync_async_callback_yields_all_items_unchanged()
+    {
+        var sut    = new ProgressReportingTransformer<int>(_ => new ValueTask());
+        var source = new[] { 10, 20, 30 };
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, result);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_async_callback_when_source_is_empty_yields_no_items()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => new ValueTask());
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(result);
+    }
+
+
+
+    // ---------- async callback — callback invocations ----------
+
+    [Fact]
+    public async Task TransformAsync_async_callback_is_called_once_per_item()
+    {
+        var seen = new List<int>();
+        var sut  = new ProgressReportingTransformer<int>(i =>
+        {
+            seen.Add(i);
+            return new ValueTask();
+        });
+        var source = new[] { 1, 2, 3 };
+
+        await CollectAsync(sut.TransformAsync(ToAsync(source)));
+
+        Assert.Equal(source, seen);
+    }
+
+
+
+    // ---------- exception propagation ----------
+
+    [Fact]
+    public async Task TransformAsync_when_sync_callback_throws_exception_propagates()
+    {
+        Action<int> callback = _ => throw new InvalidOperationException("boom");
+        var sut = new ProgressReportingTransformer<int>(callback);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("boom", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_async_callback_throws_exception_propagates()
+    {
+        Func<int, ValueTask> callback = _ => throw new InvalidOperationException("async-boom");
+        var sut = new ProgressReportingTransformer<int>(callback);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1 })))
+        );
+
+        Assert.Equal("async-boom", ex.Message);
+    }
+
+
+
+    // ---------- reference identity ----------
+
+    [Fact]
+    public async Task TransformAsync_preserves_reference_identity_of_yielded_items()
+    {
+        var a = new Box(1);
+        var b = new Box(2);
+
+        var sut = new ProgressReportingTransformer<Box>(_ => { });
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b })));
+
+        Assert.Collection
+        (
+            result,
+            item => Assert.Same(a, item),
+            item => Assert.Same(b, item)
+        );
+    }
+
+
+
+    // ---------- interface sanity ----------
+
+    [Fact]
+    public void ProgressReportingTransformer_implements_ITransformAsync()
+    {
+        var sut = new ProgressReportingTransformer<int>(_ => { });
+
+        Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
+    }
+
+
+
+    // ---------- composability ----------
+
+    [Fact]
+    public async Task ProgressReportingTransformer_composes_with_Then()
+    {
+        var seen = new List<int>();
+        ITransformAsync<int, int> reporter  = new ProgressReportingTransformer<int>(i => seen.Add(i));
+        ITransformAsync<int, int> doubleIt  = new SelectTransformer<int, int>(i => i * 2);
+
+        // reporter fires on the raw value; doubleIt fires on the doubled value
+        var pipeline = reporter.Then(doubleIt);
+
+        var result = await CollectAsync(pipeline.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 2, 4, 6 }, result);
+        Assert.Equal(new[] { 1, 2, 3 }, seen);   // raw values, not doubled
+    }
+
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+
+
+    private sealed class Box
+    {
+        public Box(int value)
+        {
+            Value = value;
+        }
+
+
+
+        public int Value { get; }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ProgressReportingTransformer<T>` — a pass-through decorator that invokes a callback for each item as it flows through the pipeline, then yields the item unchanged.

**Two constructors** (matching the library's sync/async two-ctor pattern):
```csharp
new ProgressReportingTransformer<T>(Action<T> callback)           // sync
new ProgressReportingTransformer<T>(Func<T, ValueTask> callback)  // async
```

**Typical usage — count items at a pipeline stage:**
```csharp
long count = 0;
var reporter = new ProgressReportingTransformer<Order>(item =>
    myProgress.Report(Interlocked.Increment(ref count)));

var pipeline = parse
    .Then(reporter)       // fires once per parsed order
    .Then(validate);
```

**Typical usage — log items passing through:**
```csharp
var reporter = new ProgressReportingTransformer<Row>(async row =>
{
    await logger.LogAsync($"Processing row {row.Id}");
});
```

## Design

- Pure pass-through — items emerge in the same order, with the same reference identity
- Callback fires **before** yielding to the downstream stage
- Exceptions from the callback propagate to the consumer normally
- Implements `ITransformAsync<T, T>` → composes with `.Then(...)` naturally

## Tests

18 tests covering: construction guards, null items, sync/async pass-through, callback invocation count and order, exception propagation, reference identity, and `.Then()` composability. All pass on `net10.0` and `net462`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)