### PR TITLE
feat(benchmarks): add curated .editorconfig

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,53 @@
+# Analyzer rules curated for BenchmarkDotNet benchmark projects.
+# Stacks on top of the root .editorconfig — no `root = true`.
+
+[*.cs]
+
+# --- Naming: BDN methods follow its own conventions ---
+dotnet_diagnostic.SA1300.severity = none      # Naming rules
+dotnet_diagnostic.IDE1006.severity = none     # Naming style
+dotnet_diagnostic.CA1707.severity = none      # Underscores in identifiers
+
+# --- BDN public-field params are intentional ---
+dotnet_diagnostic.CA1051.severity = none      # Do not declare visible instance fields
+dotnet_diagnostic.S2223.severity = none       # Non-constant static fields
+
+# --- Async rules: BDN baselines are sync by design ---
+dotnet_diagnostic.AsyncFixer01.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none   # Async suffix
+dotnet_diagnostic.MA0004.severity = none      # ConfigureAwait
+dotnet_diagnostic.S3216.severity = none       # ConfigureAwait
+dotnet_diagnostic.CA2007.severity = none      # ConfigureAwait
+
+# --- Banned APIs: sync I/O is often the benchmark subject ---
+dotnet_diagnostic.RS0030.severity = none
+
+# --- Documentation not required for benchmark harness types ---
+dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1602.severity = none
+dotnet_diagnostic.RCS1138.severity = none     # Missing doc summary
+
+# --- BDN GlobalSetup / IterationSetup methods are typically long ---
+dotnet_diagnostic.MA0051.severity = none      # Method is too long
+dotnet_diagnostic.S3776.severity = none       # Cognitive complexity
+
+# --- Misc relaxations appropriate for benchmark harnesses ---
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0011.severity = none      # IFormatProvider
+dotnet_diagnostic.MA0016.severity = none      # Collection abstraction
+dotnet_diagnostic.MA0036.severity = none      # Make class static
+dotnet_diagnostic.MA0038.severity = none      # Make method static
+dotnet_diagnostic.MA0040.severity = none      # Flow CancellationToken
+dotnet_diagnostic.MA0048.severity = none      # File name == type name
+dotnet_diagnostic.MA0053.severity = none      # Make class sealed
+dotnet_diagnostic.MA0076.severity = none      # Culture-sensitive ToString
+dotnet_diagnostic.S1118.severity = none       # Utility class constructors
+dotnet_diagnostic.S1144.severity = none       # Unused private members
+dotnet_diagnostic.S6966.severity = none       # Async versions
+dotnet_diagnostic.VSTHRD102.severity = none
+dotnet_diagnostic.VSTHRD103.severity = none
+dotnet_diagnostic.VSTHRD104.severity = none
+dotnet_diagnostic.VSTHRD107.severity = none
+dotnet_diagnostic.VSTHRD114.severity = none
+dotnet_diagnostic.RCS1140.severity = none     # Exception in XML doc


### PR DESCRIPTION
## Summary

- Creates `benchmarks/.editorconfig` that stacks on the root config and relaxes rules appropriate for BenchmarkDotNet harnesses (public fields for `[Params]`, no doc requirements, sync-by-design baselines, etc.)
- `TreatWarningsAsErrors` is already set globally in `Directory.Build.props` for Release builds — this editorconfig ensures benchmarks compile cleanly without suppressing anything in `src/` or `tests/`

## Test plan

- [ ] `dotnet build benchmarks/ -c Release` passes with no warnings

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)