### PR TITLE
feat(mutation): add stryker-config.json with break threshold

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,20 @@
+{
+  "stryker-config": {
+    "project": "Wolfgang.Etl.Transformers.csproj",
+    "test-projects": [
+      "tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj"
+    ],
+    "target-framework": "net10.0",
+    "thresholds": {
+      "high": 90,
+      "low": 80,
+      "break": 75
+    },
+    "reporters": [
+      "html",
+      "progress",
+      "cleartext"
+    ],
+    "output-path": "StrykerOutput"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `stryker-config.json` at the repo root, activating the existing `stryker.yaml` workflow (which was a no-op without a config file)
- Sets a break threshold of **75%** mutation score — the weekly scheduled run fails if test quality degrades below this bar
- High/low thresholds: 90/80 for dashboard colouring in the HTML report
- Points at `Wolfgang.Etl.Transformers.csproj` with the unit test project as the test suite

Current line/method coverage is 100%, so the threshold is deliberately conservative. Raise it toward 90% after a few stable weekly Stryker runs.

## Test plan

- [ ] `dotnet stryker --config-file stryker-config.json` runs and exits 0 with current test suite
- [ ] Weekly `stryker.yaml` run detects the config file and runs (check Actions tab Sunday 06:00 UTC)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)