### PR TITLE
feat(ci): publish HTML coverage report to gh-pages

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,0 +1,110 @@
+name: Coverage Report
+
+# Publishes an HTML coverage report to gh-pages/coverage/ after every
+# push to main and on each GitHub Release. Coverage data is generated
+# by Coverlet's cobertura format and rendered by ReportGenerator.
+#
+# Published URL:
+#   https://chris-wolfgang.github.io/<repo>/coverage/latest/
+#   https://chris-wolfgang.github.io/<repo>/coverage/<tag>/   (on release)
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build coverage for'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: write   # required to push to gh-pages
+
+jobs:
+  coverage-report:
+    name: Generate & Publish Coverage Report
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Run tests with coverage
+        run: |
+          dotnet test \
+            --configuration Release \
+            --framework net10.0 \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./coverage-results \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+        shell: bash
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate HTML report
+        run: |
+          reportgenerator \
+            -reports:"./coverage-results/**/coverage.cobertura.xml" \
+            -targetdir:"./coverage-html" \
+            -reporttypes:"Html;Badges" \
+            -title:"Wolfgang.Etl.Transformers Coverage"
+        shell: bash
+
+      - name: Determine version label
+        id: version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            echo "label=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages
+          persist-credentials: true
+
+      - name: Publish report to gh-pages
+        shell: bash
+        env:
+          VERSION_LABEL: ${{ steps.version.outputs.label }}
+        run: |
+          set -e
+          dest="gh-pages/coverage/${VERSION_LABEL}"
+          rm -rf "$dest"
+          mkdir -p "$dest"
+          cp -r coverage-html/. "$dest/"
+
+          # Always update coverage/latest/ to point to this build
+          rm -rf gh-pages/coverage/latest
+          mkdir -p gh-pages/coverage/latest
+          cp -r coverage-html/. gh-pages/coverage/latest/
+
+          cd gh-pages
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add coverage/
+          git diff --cached --quiet || git commit -m "coverage: publish report for ${VERSION_LABEL}"
+          git push


### PR DESCRIPTION
## Summary

Adds `.github/workflows/coverage-report.yaml` which:

- Triggers on push to `main`, GitHub Release publish, and `workflow_dispatch`
- Runs `dotnet test` with Coverlet cobertura format on `net10.0`
- Generates an HTML report + coverage badges via `reportgenerator`
- Publishes to `gh-pages/coverage/<tag>/` on release and `gh-pages/coverage/latest/` on every run

**Report URL:** `https://chris-wolfgang.github.io/ETL-Transformers/coverage/latest/`

## Test plan

- [ ] Trigger `workflow_dispatch` from Actions tab and verify report appears on GitHub Pages
- [ ] On next release, verify versioned report appears under `coverage/v0.1.0/`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)