### PR TITLE
protected-only: build config changes (ahead of dev→main release)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -351,6 +351,9 @@ dotnet_diagnostic.CA1707.severity = error
 [src/**/*.cs]
 # Documentation required
 dotnet_diagnostic.SA1600.severity = warning
+
+# A1: PublicApiAnalyzers — enforce API surface tracking
+dotnet_diagnostic.RS0016.severity = warning   # Symbol is not part of the declared API (must add to PublicAPI.Unshipped.txt)
 dotnet_diagnostic.SA1601.severity = warning
 dotnet_diagnostic.SA1602.severity = warning
 

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -79,4 +79,3 @@ M:System.Console.ReadLine(); Blocking - avoid in async code paths
 M:System.Console.Read(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(System.Boolean); Blocking - avoid in async code paths
-

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <!-- Enable nullable reference types for every SDK-style C# project.
+         The condition excludes:
+           - F# (.fsproj) and VB (.vbproj) — by the .csproj check
+           - Legacy non-SDK csproj (no Microsoft.NET.Sdk import) — by the
+             $(UsingMicrosoftNETSdk) check
+         SDK-style C# projects that need to opt out can set
+         <Nullable>disable</Nullable> in their own csproj. -->
+    <Nullable Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(UsingMicrosoftNETSdk)' == 'true'">enable</Nullable>
 
     <!-- Enable .NET analyzers -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -56,4 +64,49 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
+         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
+         project directory and the analyzer activates for that project only.
+         Library projects under src/ should opt in; test / example /
+         benchmark projects should not. Per-repo enablement is tracked as a
+         follow-up maintenance issue. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" Condition="Exists('PublicAPI.Shipped.txt')" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI.Unshipped.txt')" />
+  </ItemGroup>
+
+
+  <PropertyGroup>
+    <!-- CI3: NuGet package metadata canonical defaults. Per-repo fields
+         (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
+         PackageLicenseExpression, PackageReadmeFile) stay in each src
+         csproj where they are repo-specific. -->
+    <Authors>Chris Wolfgang</Authors>
+    <Company>Chris Wolfgang</Company>
+    <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SourceLink: embed source provenance into PDBs so debuggers can step
+         into NuGet package code from GitHub. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Protected-only PR

This PR contains **only the protected config files** from the `dev` branch so they can be admin-bypassed separately, keeping the scope of the bypass small and auditable.

### Files changed (3)

| File | Change |
|------|--------|
| `.editorconfig` | Add `RS0016 = warning` to `[src/**/*.cs]` — enforces PublicApiAnalyzers tracking |
| `Directory.Build.props` | Add PublicApiAnalyzers reference + AdditionalFiles wiring; CI3 NuGet defaults (Authors, Copyright, SourceLink, IncludeSymbols, EmbedUntrackedSources); nullable-enable for all SDK-style C# projects |
| `BannedSymbols.txt` | Remove stale entry |

### Why this PR exists

`pr.yaml`'s *Detect .NET Projects* step blocks any PR touching these files. Rather than admin-bypassing the entire 142-commit `dev → main` release PR, we extract protected files into this minimal PR so:
- The bypass is scoped to **3 files** that are easy to review
- PR #64 (`dev → main`) can then merge through the normal checks

### Expected CI behaviour

- ❌ **Detect .NET Projects** — expected failure (that's why this PR exists)
- ✅ All other checks (Secrets Scan, DevSkim, CodeQL, Stage 1/2/3 are skipped when the guard fires)

**Admin-bypass required at merge.**

Companion PR: [protected/workflows](#) — open next.
Source PR: #64 (dev → main release).