### PR TITLE
refactor(tests): extract shared ToAsync/CollectAsync helpers

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -347,29 +348,6 @@ public class BufferedTransformerTests
 
 
     // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
-
-
 
     /// <summary>
     /// An infinite source that signals via the supplied <see cref="TaskCompletionSource{TResult}"/>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -187,31 +188,6 @@ public class CastTransformerTests
         var sut = new CastTransformer<object, string>();
 
         Assert.IsAssignableFrom<ITransformAsync<object, string>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChainTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChainTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -283,26 +284,4 @@ public class ChainTransformerTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChainTransformerWithCancellationTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChainTransformerWithCancellationTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -252,31 +253,6 @@ public class ChainTransformerWithCancellationTests
         );
 
         Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -263,31 +264,6 @@ public class ChunkTransformerTests
         var sut = new ChunkTransformer<int>(size: 1);
 
         Assert.IsAssignableFrom<ITransformAsync<int, int[]>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctByTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctByTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -224,31 +225,6 @@ public class DistinctByTransformerTests
         var sut = new DistinctByTransformer<Person, int>(p => p.Id);
 
         Assert.IsAssignableFrom<ITransformAsync<Person, Person>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/DistinctTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -173,31 +174,6 @@ public class DistinctTransformerTests
         var sut = new DistinctTransformer<int>();
 
         Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/OfTypeTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/OfTypeTransformerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -170,31 +171,6 @@ public class OfTypeTransformerTests
         var sut = new OfTypeTransformer<object, string>();
 
         Assert.IsAssignableFrom<ITransformAsync<object, string>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -190,29 +191,6 @@ public class PassThroughTransformerTests
 
 
     // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
-
-
 
     private static IEnumerable<int> InfiniteSource()
     {

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -283,31 +284,6 @@ public class ProgressReportingTransformerTests
 
         Assert.Equal(new[] { 2, 4, 6 }, result);
         Assert.Equal(new[] { 1, 2, 3 }, seen);   // raw values, not doubled
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectManyTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectManyTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -275,26 +276,4 @@ public class SelectManyTransformerTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SelectTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -196,26 +197,4 @@ public class SelectTransformerTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -196,26 +197,4 @@ public class SkipTransformerTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipWhileTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/SkipWhileTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -272,26 +273,4 @@ public class SkipWhileTransformerTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -207,17 +208,6 @@ public class TakeTransformerTests
 
     // ---------- helpers ----------
 
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
     private static async IAsyncEnumerable<T> CountingSource<T>(IEnumerable<T> items, Action onItem)
     {
         foreach (var item in items)
@@ -230,13 +220,4 @@ public class TakeTransformerTests
 
 
 
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeWhileTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TakeWhileTransformerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -249,17 +250,6 @@ public class TakeWhileTransformerTests
 
     // ---------- helpers ----------
 
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
     private static async IAsyncEnumerable<T> CountingSource<T>(IEnumerable<T> items, Action onItem)
     {
         foreach (var item in items)
@@ -272,13 +262,4 @@ public class TakeWhileTransformerTests
 
 
 
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TestHelpers.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TestHelpers.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+internal static class TestHelpers
+{
+    internal static async IAsyncEnumerable<T> ToAsync<T>(
+        IEnumerable<T> items,
+        [EnumeratorCancellation] System.Threading.CancellationToken token = default)
+    {
+        foreach (var item in items)
+        {
+            token.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+
+    internal static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/TransformerExtensionsTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -363,26 +364,4 @@ public class TransformerExtensionsTests
 
 
 
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
-    }
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/WhereTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/WhereTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
 
 
 
@@ -242,31 +243,6 @@ public class WhereTransformerTests
         var sut = new WhereTransformer<int>(predicate);
 
         Assert.IsAssignableFrom<ITransformAsync<int, int>>(sut);
-    }
-
-
-
-    // ---------- helpers ----------
-
-    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> items)
-    {
-        var list = new List<T>();
-        await foreach (var item in items)
-        {
-            list.Add(item);
-        }
-        return list;
     }
 
 


### PR DESCRIPTION
## Summary
- Extracted duplicate `ToAsync<T>` and `CollectAsync<T>` helper methods from all 18 unit test files into a shared `internal static class TestHelpers`
- Each test file now uses `using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;`
- No test logic changed; 257 tests still passing

## Test plan
- [x] `dotnet test` passes on all TFMs (257 tests)
- [x] No duplicate helper methods remain in individual test files

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)