### PR TITLE
docs: fix code-review findings from issue #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - Upcoming
+## [0.1.0] - 2026-06-20
 
 ### Added
 
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ProgressReportingTransformer<T>` (per-item callback without altering the stream)
 - **Composition**: `ChainTransformer<TSource, TIntermediate, TDestination>`,
   `ChainTransformerWithCancellation<TSource, TIntermediate, TDestination>`,
-  `TransformerExtensions.Then(...)` (4 overloads), `TransformerExtensions.Buffered(...)`
-- Multi-TFM targeting: .NET Framework 4.6.2–4.8.1, .NET Core 3.1, .NET 5.0–10.0
-- 231 unit tests with 100% line and method coverage across all 13 target frameworks
+  `TransformerExtensions.Then(...)` (2 overloads), `TransformerExtensions.Buffered(...)`
+- Multi-TFM targeting: .NET Framework 4.6.2–4.8.1, .NET Standard 2.0, .NET 5.0–10.0
+- 257 unit tests + 11 integration tests with 100% line and method coverage
 - BenchmarkDotNet project for baseline performance measurement
 - Full DocFX API documentation site
+
+[0.1.0]: https://github.com/Chris-Wolfgang/ETL-Transformers/releases/tag/v0.1.0

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -6,7 +6,6 @@
     <File Path="Directory.Build.props" />
     <File Path="LICENSE" />
     <File Path="README.md" />
-    <File Path="REPO-INSTRUCTIONS.md" />
     <File Path="SECURITY.md" />
   </Folder>
   <Folder Name="/.root/.github/">
@@ -28,16 +27,11 @@
   </Folder>
   <Folder Name="/.root/docs/">
     <File Path="docs/RELEASE-WORKFLOW-SETUP.md" />
-    <File Path="docs/SECURITY.md" />
   </Folder>
   <Folder Name="/.root/scripts/">
     <File Path="scripts/build-pr.ps1" />
-    <File Path="scripts/Fix-BranchRuleset.ps1" />
     <File Path="scripts/format.ps1" />
-    <File Path="scripts/Setup-BranchRuleset.ps1" />
-    <File Path="scripts/Setup-GitHubPages.ps1" />
     <File Path="scripts/Setup-Labels.ps1" />
-    <File Path="scripts/setup.ps1" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj" />

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ await foreach (var row in pipeline.TransformAsync(rawLines))
     await loader.LoadAsync(row);
 }
 
-// Or use extension methods inline:
-await foreach (var row in rawLines
-    .Buffered(capacity: 500)
-    .SelectAsync(ParseOrder)
-    .WhereAsync(o => o.IsValid)
-    .SelectAsync(ToInvoice))
+// Or buffer inline between pipeline stages:
+var buffered = rawLines.Buffered(capacity: 500);
+var filtered = new WhereTransformer<Order>(o => o.IsValid);
+var projected = new SelectTransformer<Order, InvoiceRow>(ToInvoice);
+
+await foreach (var row in projected.TransformAsync(filtered.TransformAsync(buffered)))
 {
     await loader.LoadAsync(row);
 }
@@ -78,7 +78,7 @@ await foreach (var row in rawLines
 |---------------|-------------|
 | `ChainTransformer<TSource, TIntermediate, TDestination>` | Composes two `ITransformAsync` transformers into one |
 | `ChainTransformerWithCancellation<TSource, TIntermediate, TDestination>` | Same as above but propagates `CancellationToken` through both stages |
-| `TransformerExtensions.Then(...)` | Fluent composition — four overloads covering sync × cancellation combinations |
+| `TransformerExtensions.Then(...)` | Fluent composition — two overloads: one for `ITransformAsync` pairs, one for `ITransformWithCancellationAsync` pairs |
 | `TransformerExtensions.Buffered(...)` | Inline buffer insertion — sugar for `new BufferedTransformer<T>(n).TransformAsync(source)` |
 
 ---
@@ -87,8 +87,8 @@ await foreach (var row in rawLines
 
 | Framework | Versions |
 |-----------|----------|
-| .NET Framework | 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8, 4.8.1 |
-| .NET Core | 3.1 |
+| .NET Framework | 4.6.2, 4.7.2, 4.8, 4.8.1 |
+| .NET Standard | 2.0 |
 | .NET | 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 |
 
 ---

--- a/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/TransformerExtensions.cs
@@ -35,11 +35,9 @@ public static class TransformerExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    ///     var results = await extractor
-    ///         .ExtractAsync(token)
-    ///         .Buffered(capacity: 500)
-    ///         .SelectAsync(Parse)
-    ///         .ToListAsync();
+    ///     var select = new SelectTransformer&lt;RawRecord, ParsedRecord&gt;(Parse);
+    ///     var results = select.TransformAsync(extractor.ExtractAsync(token).Buffered(capacity: 500));
+    ///     await foreach (var item in results) { ... }
     /// </code>
     /// </example>
     public static IAsyncEnumerable<T> Buffered<T>


### PR DESCRIPTION
## Summary
Actioned all must-fix and should-fix findings from the AI full code-review pass (#38):

- **CHANGELOG.md**: `[0.1.0] - Upcoming` → `[0.1.0] - 2026-06-20` (actual release date); updated test count (231 → 257 unit + 11 integration); fixed "4 overloads" → "2 overloads"; added Keep-a-Changelog footer link; corrected TFM list (removed `.NET Core 3.1`, added `.NET Standard 2.0`)
- **README.md**: Fixed "four overloads" → "two overloads" for `Then(...)`; replaced Quick Start second example that used `SelectAsync`/`WhereAsync` from a different package with a self-contained example; corrected Target Frameworks table (net4.7/net4.7.1 → net4.7.2, added .NET Standard 2.0, removed .NET Core 3.1)
- **ETL-Transformers.slnx**: Removed 6 references to files that were never created: `REPO-INSTRUCTIONS.md`, `docs/SECURITY.md`, `scripts/Fix-BranchRuleset.ps1`, `scripts/Setup-BranchRuleset.ps1`, `scripts/Setup-GitHubPages.ps1`, `scripts/setup.ps1`
- **TransformerExtensions.cs**: Replaced `<example>` code block on `Buffered()` that used `SelectAsync`/`ToListAsync` from `Wolfgang.IAsyncEnumerable.Extensions` with a self-contained example using only this package

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)