### PR TITLE
chore: release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-20
+
+### Changed
+
+- Corrected README Target Frameworks table (removed net4.7/net4.7.1, added .NET Standard 2.0)
+- Fixed README and CHANGELOG `Then(...)` overload count: two overloads, not four
+- Replaced README Quick Start inline-extension example with a self-contained example using only this package
+- Updated CHANGELOG v0.1.0 entry: release date, test count (257 unit + 11 integration), Keep-a-Changelog footer link
+
+### Added
+
+- Integration test project (`Wolfgang.Etl.Transformers.Tests.Integration`) with 11 pipeline composition tests
+- Shared `TestHelpers` class in the unit test project (eliminates duplicate `ToAsync`/`CollectAsync` helpers)
+- Documentation version picker (`docfx_project/public/version-picker.js` + `versions.json`)
+- Canonical `benchmarks.yaml` GitHub Actions workflow (interactive BenchmarkDotNet line chart on gh-pages)
+
+### Fixed
+
+- `ETL-Transformers.slnx`: removed references to 6 files that were never created after template setup
+
+[0.1.1]: https://github.com/Chris-Wolfgang/ETL-Transformers/compare/v0.1.0...v0.1.1
+
 ## [0.1.0] - 2026-06-20
 
 ### Added

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.1.0</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <Version>0.1.1</Version>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.Transformers</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
## Summary
Bumps version to 0.1.1 and records the Tier-1 maintenance batch in CHANGELOG.

### What's in 0.1.1
- Integration test project (11 pipeline composition tests)
- Shared `TestHelpers` in unit tests (extract duplicate `ToAsync`/`CollectAsync`)
- Docs version picker (`version-picker.js`, `versions.json`)
- Canonical `benchmarks.yaml` workflow
- slnx cleanup (6 stale file references removed)
- README and CHANGELOG accuracy fixes (TFM table, Then overload count, Quick Start example)

No public API changes — patch release.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)