### PR TITLE
feat!: ChunkTransformer yields IReadOnlyList<T> instead of T[]

### DIFF
--- a/examples/LinqOps/Program.cs
+++ b/examples/LinqOps/Program.cs
@@ -35,6 +35,7 @@
 // ---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -86,7 +87,7 @@ var pipeline = new WhereTransformer<int>(i => i % 2 == 0)
 // ---------------------------------------------------------------------------
 
 var extractor = new TestExtractor<int>(source);
-var loader = new TestLoader<Bucket[]>(collectItems: true);
+var loader = new TestLoader<IReadOnlyList<Bucket>>(collectItems: true);
 var token = CancellationToken.None;
 
 await loader.LoadAsync
@@ -111,13 +112,13 @@ foreach (var chunk in loader.GetCollectedItems()!)
 {
     chunkIndex++;
     var rendered = string.Join(", ", chunk.Select(b => $"({b.Number},{b.Label})"));
-    Console.WriteLine($"  chunk #{chunkIndex} ({chunk.Length} item{(chunk.Length == 1 ? string.Empty : "s")}):  {rendered}");
+    Console.WriteLine($"  chunk #{chunkIndex} ({chunk.Count} item{(chunk.Count == 1 ? string.Empty : "s")}):  {rendered}");
 }
 
 Console.WriteLine(new string('-', 70));
 var chunks = loader.GetCollectedItems()!;
 Console.WriteLine($"Total chunks emitted: {chunks.Count}");
-Console.WriteLine($"Total Bucket items:   {chunks.Sum(c => c.Length)}");
+Console.WriteLine($"Total Bucket items:   {chunks.Sum(c => c.Count)}");
 
 // ---------------------------------------------------------------------------
 // Bucket - intermediate record type produced by the Select stage.

--- a/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
@@ -8,8 +8,8 @@ using Wolfgang.Etl.Abstractions;
 namespace Wolfgang.Etl.Transformers;
 
 /// <summary>
-/// A transformer that batches the input sequence into arrays of a fixed size and yields each
-/// batch as a single output item.
+/// A transformer that batches the input sequence into fixed-size groups and yields each batch as
+/// a single <see cref="IReadOnlyList{T}"/> output item.
 /// </summary>
 /// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
 /// <remarks>
@@ -20,9 +20,9 @@ namespace Wolfgang.Etl.Transformers;
 /// if the input length is not an exact multiple of <see cref="Size"/>.
 /// </para>
 /// <para>
-/// Each yielded chunk is a freshly-allocated <typeparamref name="T"/>[] - chunks do not share
-/// backing storage with the transformer or with each other. Consumers are free to retain or
-/// mutate each chunk without affecting subsequent output.
+/// Each yielded chunk is backed by a freshly-allocated <typeparamref name="T"/>[] (exposed as
+/// <see cref="IReadOnlyList{T}"/>) - chunks do not share backing storage with the transformer or
+/// with each other, so consumers can retain each chunk without affecting subsequent output.
 /// </para>
 /// <para>
 /// Useful for batching writes to a downstream loader (e.g. <c>SqlBulkCopy</c>) without
@@ -39,7 +39,7 @@ namespace Wolfgang.Etl.Transformers;
 ///     var batches = new ChunkTransformer&lt;Row&gt;(size: 1000);
 /// </code>
 /// </example>
-public sealed class ChunkTransformer<T> : ITransformAsync<T, T[]>
+public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
     where T : notnull
 {
     private readonly int _size;
@@ -73,9 +73,9 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, T[]>
     /// is not a multiple of <see cref="Size"/>.
     /// </summary>
     /// <param name="items">The asynchronous source sequence.</param>
-    /// <returns>An asynchronous sequence of arrays, each containing up to <see cref="Size"/> items.</returns>
+    /// <returns>An asynchronous sequence of read-only lists, each containing up to <see cref="Size"/> items.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
-    public IAsyncEnumerable<T[]> TransformAsync(IAsyncEnumerable<T> items)
+    public IAsyncEnumerable<IReadOnlyList<T>> TransformAsync(IAsyncEnumerable<T> items)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(items);
@@ -100,7 +100,7 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, T[]>
 
 
 
-    private static async IAsyncEnumerable<T[]> ChunkAsync(IAsyncEnumerable<T> items, int size)
+    private static async IAsyncEnumerable<IReadOnlyList<T>> ChunkAsync(IAsyncEnumerable<T> items, int size)
     {
         var buffer = new T[size];
         var index = 0;

--- a/src/Wolfgang.Etl.Transformers/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Transformers/PublicAPI.Shipped.txt
@@ -19,7 +19,7 @@ Wolfgang.Etl.Transformers.ChainTransformerWithCancellation<TSource, TIntermediat
 Wolfgang.Etl.Transformers.ChunkTransformer<T>
 Wolfgang.Etl.Transformers.ChunkTransformer<T>.ChunkTransformer(int size) -> void
 Wolfgang.Etl.Transformers.ChunkTransformer<T>.Size.get -> int
-Wolfgang.Etl.Transformers.ChunkTransformer<T>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<T>! items) -> System.Collections.Generic.IAsyncEnumerable<T[]!>!
+Wolfgang.Etl.Transformers.ChunkTransformer<T>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<T>! items) -> System.Collections.Generic.IAsyncEnumerable<System.Collections.Generic.IReadOnlyList<T>!>!
 Wolfgang.Etl.Transformers.DistinctByTransformer<TSource, TKey>
 Wolfgang.Etl.Transformers.DistinctByTransformer<TSource, TKey>.DistinctByTransformer(System.Func<TSource, TKey>! keySelector) -> void
 Wolfgang.Etl.Transformers.DistinctByTransformer<TSource, TKey>.DistinctByTransformer(System.Func<TSource, TKey>! keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) -> void

--- a/tests/Wolfgang.Etl.Transformers.Tests.Integration/PipelineIntegrationTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Integration/PipelineIntegrationTests.cs
@@ -148,7 +148,7 @@ public class PipelineIntegrationTests
         // Arrange: chunk into groups of 3, then sum each group
         var source = Enumerable.Range(1, 9);
         var chunk = new ChunkTransformer<int>(3);
-        var select = new SelectTransformer<int[], int>(arr => arr.Sum());
+        var select = new SelectTransformer<IReadOnlyList<int>, int>(arr => arr.Sum());
 
         // Act
         var result = await CollectAsync(select.TransformAsync(chunk.TransformAsync(ToAsync(source))));

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
@@ -175,17 +175,17 @@ public class ChunkTransformerTests
     // ---------- chunks are independent arrays (no aliasing) ----------
 
     [Fact]
-    public async Task TransformAsync_yields_independent_chunk_arrays()
+    public async Task TransformAsync_yields_independent_chunk_instances()
     {
         var sut = new ChunkTransformer<int>(size: 2);
 
         var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4 })));
 
         Assert.Equal(2, result.Count);
-        Assert.NotSame(result[0], result[1]);
 
-        // Mutating one chunk must not affect the other
-        result[0][0] = 999;
+        // Each chunk is a distinct instance — chunks do not share backing storage.
+        Assert.NotSame(result[0], result[1]);
+        Assert.Equal(new[] { 1, 2 }, result[0]);
         Assert.Equal(new[] { 3, 4 }, result[1]);
     }
 
@@ -201,8 +201,8 @@ public class ChunkTransformerTests
         var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4, 5, 6, 7 })));
 
         Assert.Equal(2, result.Count);
-        Assert.Equal(5, result[0].Length);
-        Assert.Equal(2, result[1].Length);   // not 5 with default trailing values
+        Assert.Equal(5, result[0].Count);
+        Assert.Equal(2, result[1].Count);   // not 5 with default trailing values
     }
 
 
@@ -263,7 +263,7 @@ public class ChunkTransformerTests
     {
         var sut = new ChunkTransformer<int>(size: 1);
 
-        Assert.IsAssignableFrom<ITransformAsync<int, int[]>>(sut);
+        Assert.IsAssignableFrom<ITransformAsync<int, IReadOnlyList<int>>>(sut);
     }
 
 


### PR DESCRIPTION
## Summary

Changes `ChunkTransformer<T>` to implement `ITransformAsync<T, IReadOnlyList<T>>` and return `IAsyncEnumerable<IReadOnlyList<T>>` instead of `IAsyncEnumerable<T[]>`.

This is the "readonlylist" capability requested for chunking.

## ⚠️ Read before merging — this is a breaking change with a real trade-off

`ITransformAsync<in TSource, out TDestination>` is **covariant** in `TDestination`, and `T[] : IReadOnlyList<T>`. That means the **existing released** `ChunkTransformer<T>` (`ITransformAsync<T, T[]>`) is *already* usable anywhere `ITransformAsync<T, IReadOnlyList<T>>` is expected — and `ILoadAsync<T>` is contravariant, so an `IReadOnlyList<T>`-based loader already consumes the `T[]` stream.

So this PR does **not** add a new consumption capability. What it actually does:

- **Gains:** an immutable public surface — consumers can no longer mutate emitted chunks via the indexer.
- **Loses:** the concrete-array return. Code that wanted `T[]` (e.g. `Array.Sort`, `Span<T>`, fast copy) no longer gets it without a cast.

Net: it's a **breaking, slightly-reductive** change whose only real upside is immutability. I built it because you asked to see it; my recommendation remains that this may not be worth the break given covariance already covers the read-only use case.

## Ripple effect (illustrates the break)

Every downstream consumer that hard-coded the element type had to change:
- `SelectTransformer<int[], int>` → `SelectTransformer<IReadOnlyList<int>, int>` (integration test)
- `TestLoader<Bucket[]>` → `TestLoader<IReadOnlyList<Bucket>>`, `chunk.Length` → `chunk.Count` (LinqOps example)
- A test that mutated a chunk to prove independence was rewritten to assert distinct instances instead (mutation is no longer part of the contract).

## Validation
- Full solution builds clean (Release / TreatWarningsAsErrors, all TFMs)
- 257 unit + 11 integration tests pass
- `PublicAPI.Shipped.txt` updated for the new return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)