### PR TITLE
feat: optional IProgress<int> sink for ChunkTransformer

### DIFF
--- a/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ChunkTransformer.cs
@@ -29,20 +29,27 @@ namespace Wolfgang.Etl.Transformers;
 /// materializing the entire stream.
 /// </para>
 /// <para>
-/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no progress, no
-/// cancellation, no Skip/Max - to keep the hot loop minimal.
+/// Implements only <see cref="ITransformAsync{TSource, TDestination}"/> - no cancellation, no
+/// Skip/Max - to keep the hot loop minimal. An optional <see cref="IProgress{T}"/> sink may be
+/// supplied to receive the running count of source items consumed; when none is supplied the
+/// hot path allocates and reports nothing.
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
 ///     // batch rows into groups of 1000 for bulk loading
 ///     var batches = new ChunkTransformer&lt;Row&gt;(size: 1000);
+///
+///     // batch and report progress as items are consumed
+///     var progress = new Progress&lt;int&gt;(n =&gt; Console.WriteLine($"{n} rows chunked"));
+///     var tracked = new ChunkTransformer&lt;Row&gt;(size: 1000, progress);
 /// </code>
 /// </example>
 public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
     where T : notnull
 {
     private readonly int _size;
+    private readonly IProgress<int>? _progress;
 
 
 
@@ -68,6 +75,24 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
 
 
     /// <summary>
+    /// Initializes a new instance with the given chunk size and a progress sink that receives the
+    /// running count of source items consumed.
+    /// </summary>
+    /// <param name="size">The maximum number of items in each yielded chunk. Must be at least 1.</param>
+    /// <param name="progress">
+    /// A sink that receives the cumulative number of source items consumed so far, reported once per
+    /// yielded chunk (including the partial final chunk). May be <see langword="null"/> to disable reporting.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is less than 1.</exception>
+    public ChunkTransformer(int size, IProgress<int>? progress)
+        : this(size)
+    {
+        _progress = progress;
+    }
+
+
+
+    /// <summary>
     /// Asynchronously yields successive chunks of <see cref="Size"/> consecutive items from
     /// <paramref name="items"/>. The last chunk may contain fewer items if the source length
     /// is not a multiple of <see cref="Size"/>.
@@ -88,7 +113,7 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
 #pragma warning restore RCS1140
 #endif
 
-        return ChunkAsync(items, _size);
+        return ChunkAsync(items, _size, _progress);
     }
 
 
@@ -100,18 +125,21 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
 
 
 
-    private static async IAsyncEnumerable<IReadOnlyList<T>> ChunkAsync(IAsyncEnumerable<T> items, int size)
+    private static async IAsyncEnumerable<IReadOnlyList<T>> ChunkAsync(IAsyncEnumerable<T> items, int size, IProgress<int>? progress)
     {
         var buffer = new T[size];
         var index = 0;
+        var itemsConsumed = 0;
 
         await foreach (var item in items.ConfigureAwait(continueOnCapturedContext: false))
         {
             buffer[index++] = item;
+            itemsConsumed++;
 
             if (index == size)
             {
                 yield return buffer;
+                progress?.Report(itemsConsumed);
                 buffer = new T[size];
                 index = 0;
             }
@@ -124,6 +152,7 @@ public sealed class ChunkTransformer<T> : ITransformAsync<T, IReadOnlyList<T>>
             var partial = new T[index];
             Array.Copy(buffer, partial, index);
             yield return partial;
+            progress?.Report(itemsConsumed);
         }
     }
 }

--- a/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Wolfgang.Etl.Transformers.ChunkTransformer<T>.ChunkTransformer(int size, System.IProgress<int>? progress) -> void

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
@@ -268,7 +268,84 @@ public class ChunkTransformerTests
 
 
 
+    // ---------- progress reporting ----------
+
+    [Fact]
+    public void Ctor_with_progress_when_size_is_zero_throws_ArgumentOutOfRangeException()
+    {
+        var progress = new ListProgress<int>();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ChunkTransformer<int>(size: 0, progress));
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_progress_reports_cumulative_item_count_per_chunk()
+    {
+        var progress = new ListProgress<int>();
+        var sut = new ChunkTransformer<int>(size: 3, progress);
+
+        _ = await CollectAsync(sut.TransformAsync(ToAsync(Enumerable.Range(1, 9).ToArray())));
+
+        Assert.Equal(new[] { 3, 6, 9 }, progress.Reports);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_progress_reports_partial_final_chunk()
+    {
+        var progress = new ListProgress<int>();
+        var sut = new ChunkTransformer<int>(size: 3, progress);
+
+        _ = await CollectAsync(sut.TransformAsync(ToAsync(Enumerable.Range(1, 7).ToArray())));
+
+        Assert.Equal(new[] { 3, 6, 7 }, progress.Reports);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_progress_reports_nothing_for_empty_source()
+    {
+        var progress = new ListProgress<int>();
+        var sut = new ChunkTransformer<int>(size: 3, progress);
+
+        _ = await CollectAsync(sut.TransformAsync(ToAsync(Array.Empty<int>())));
+
+        Assert.Empty(progress.Reports);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_null_progress_does_not_throw()
+    {
+        var sut = new ChunkTransformer<int>(size: 3, progress: null);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3, 4 })));
+
+        Assert.Equal(2, result.Count);
+    }
+
+
+
     // test fixtures
+
+    private sealed class ListProgress<TValue> : IProgress<TValue>
+    {
+        public List<TValue> Reports { get; } = new();
+
+
+
+        public void Report(TValue value)
+        {
+            Reports.Add(value);
+        }
+    }
+
+
 
     private sealed class Box
     {


### PR DESCRIPTION
## Summary

Adds a second constructor `ChunkTransformer(int size, IProgress<int>? progress)`. When a sink is supplied, the transformer reports the **cumulative count of source items consumed** once per yielded chunk (including the partial final chunk). With no sink, the hot path reports nothing — the lean default is preserved.

This is the "progress" capability requested for chunking.

> **Stacked on #129** (`feat/chunk-readonlylist`). Review/merge that first — this PR's diff is just the progress addition on top of it.

## Honest note on whether this is needed

Per-chunk progress is **already composable today** without any change to `ChunkTransformer`:

```csharp
chunker.Then(new ProgressReportingTransformer<IReadOnlyList<Row>>(
    batch => myProgress.Report(/* ... */)))
```

The library deliberately keeps `ChunkTransformer` lean ("no progress... to keep the hot loop minimal") and ships `ProgressReportingTransformer` + `.Then(...)` for exactly this. So this overload is a **built-in convenience**, not a new capability — and it slightly softens that lean-by-design stance. I built it because you asked to see it; it's a reasonable ergonomic add if you'd rather offer chunk progress out of the box than via composition.

One semantic difference worth noting: this reports **items consumed** (the framework's `CurrentItemCount` idiom), whereas the decorator reports **per chunk emitted**. Pick whichever matches the intent.

## Validation
- Full solution builds clean (Release / TreatWarningsAsErrors, all TFMs)
- 262 unit (+5 new) + 11 integration tests pass
- New ctor recorded in `PublicAPI.Unshipped.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)