### PR TITLE
chore: bump Abstractions to 0.14.1 and TestKit to 0.9.0

### DIFF
--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -38,15 +38,15 @@
     prevent NuGet from resolving an older transitive version - no runtime assembly is copied.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.5" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.12.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />


### PR DESCRIPTION
Bumps to the latest published packages.

- `Wolfgang.Etl.Abstractions` 0.12.0 → **0.14.1** (src) — a two-minor jump, but the `TransformerBase` API was compatible (no code changes needed).
- `Microsoft.Bcl.AsyncInterfaces` 10.0.5 → **10.0.9** (src + both test projects)
- `Wolfgang.Etl.TestKit` 0.8.0 → **0.9.0** (examples: BasicChain, LinqOps)

This repo has no test-project TestKit reference — TestKit is consumed only by the examples.

Verified locally: **262/262** unit tests pass; multi-TFM Release build and both examples build clean.

> Note: no `vNext` branch exists in this repo, so this targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)