### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-26
+
+### Changed
+
+- **Breaking:** `ChunkTransformer<T>` now produces `IReadOnlyList<T>` instead of `T[]` (`ITransformAsync<T, IReadOnlyList<T>>`). Callers that relied on the array contract (indexing a `T[]` variable, passing chunks where an array is required) must adjust to the read-only list.
+- Bumped `Wolfgang.Etl.Abstractions` to 0.14.1 and `Microsoft.Bcl.AsyncInterfaces` to 10.0.9.
+
+### Added
+
+- `ChunkTransformer<T>` gains a constructor overload accepting an optional `IProgress<int>?` sink that reports the cumulative item count as chunks are produced.
+
 ## [0.1.1] - 2026-06-20
 
 ### Changed
@@ -27,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ETL-Transformers.slnx`: removed references to 6 files that were never created after template setup
 
+[0.2.0]: https://github.com/Chris-Wolfgang/ETL-Transformers/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/Chris-Wolfgang/ETL-Transformers/compare/v0.1.0...v0.1.1
 
 ## [0.1.0] - 2026-06-20

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.1.1</Version>
-    <AssemblyVersion>0.1.1.0</AssemblyVersion>
-    <FileVersion>0.1.1.0</FileVersion>
+    <Version>0.2.0</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.Transformers</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
Release prep for **v0.2.0** (MINOR — driven by the breaking `ChunkTransformer` return-type change on 0.x).

- Bump `<Version>`/`<AssemblyVersion>`/`<FileVersion>` 0.1.1 → **0.2.0**
- Add CHANGELOG `[0.2.0]` section:
  - **Breaking:** `ChunkTransformer<T>` yields `IReadOnlyList<T>` instead of `T[]`
  - Added: optional `IProgress<int>?` sink on `ChunkTransformer<T>`
  - Changed: Abstractions → 0.14.1, Microsoft.Bcl.AsyncInterfaces → 10.0.9

Coverage 100% on the assembly; 262 unit tests pass. After merge, cut `v0.2.0` (`gh release create v0.2.0 --target main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)