### PR TITLE
chore(deps): bump test-project dependencies

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Dependabot-style sweep — **test-project dependencies** (no change to the shipped `Wolfgang.Etl.Transformers` package).

- `Microsoft.Bcl.Memory` 10.0.5 → **10.0.9**
- `System.Linq.Async` 7.0.0 → **7.0.1**
- `Microsoft.NET.Test.Sdk` 18.3.0 → **18.7.0** (net8.0+ leg; the 17.13.0 conditional stays for netcoreapp3.1/net5.0 and pre-net8 TFMs, which 18.x dropped)
- `coverlet.collector` 8.0.1 → **10.0.1**

> `xunit.runner.visualstudio` deliberately left at **2.8.2** — Dependabot would propose 3.1.5, but 3.x is incompatible with xunit v2.

Verified: solution builds clean, **262/262** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)