### PR TITLE
chore(deps): bump analyzer/tooling packages (Directory.Build.props)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     </PackageReference>
     
     <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.114">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -104,7 +104,7 @@
   <ItemGroup>
     <!-- SourceLink: embed source provenance into PDBs so debuggers can step
          into NuGet package code from GitHub. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Dependabot-style sweep — **analyzer/tooling packages** in `Directory.Build.props`. Split into its own PR because `Directory.Build.props` is a protected file (the `Detect .NET Projects` guard blocks it), so this one needs an **admin bypass** to merge.

- `Microsoft.VisualStudio.Threading.Analyzers` 17.14.15 → **18.7.23**
- `Meziantou.Analyzer` 3.0.58 → **3.0.114**
- `SonarAnalyzer.CSharp` 10.25.0.139117 → **10.27.0.140913**
- `Microsoft.SourceLink.GitHub` 8.0.0 → **10.0.300**

Verified: solution builds clean with **no new analyzer diagnostics** (despite the major bumps), **262/262** unit tests pass.

> ⚠️ Admin bypass waives *all* ruleset gates at once. CI is green and the diff is four version strings, but be aware nothing else is enforced on the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)