### PR TITLE
ci(release): switch to NuGet Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -677,6 +677,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -697,7 +700,7 @@ jobs:
           path: ./packages
 
       - name: NuGet login (OIDC → temporary API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: nuget-login
         with:
           user: Chris-Wolfgang

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -666,7 +666,12 @@ jobs:
           }
           Write-Host "Documentation built successfully - release may proceed"
 
-  # Publish to NuGet (only if validation passed)
+  # Publish the built .nupkg files to NuGet.org via Trusted Publishing (OIDC).
+  # Requires a Trusted Publishing policy configured on nuget.org for:
+  #   owner=Chris-Wolfgang, repo=ETL-Transformers, workflow=release.yaml
+  # No NUGET_API_KEY secret required — NuGet/login exchanges the workflow's
+  # OIDC token for a 1-hour temporary API key, so the login MUST run
+  # immediately before the push (not at job start).
   publish-nuget:
     name: Publish to NuGet.org
     needs: [pack-and-validate, verify-docs-build]
@@ -691,22 +696,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           


### PR DESCRIPTION
## Summary

Switches this repo's `release.yaml` from a static `NUGET_API_KEY` secret to **NuGet Trusted Publishing (OIDC)** via `NuGet/login@v1`, matching the pilot pattern in ETL-SqlBulkCopy.

## Why

The previous release attempt (`v0.2.1`) 403'd during `dotnet nuget push` because the shared `NUGET_API_KEY` secret was either expired or scope-limited. Trusted Publishing eliminates the secret entirely — the workflow exchanges its GitHub-issued OIDC token for a short-lived (1 hour) NuGet API key just before the push.

## Prerequisites (already done)

A Trusted Publishing policy has been configured on nuget.org for this package with:

- **Repository owner:** `Chris-Wolfgang`
- **Repository name:** `ETL-Transformers`
- **Workflow filename:** `release.yaml`
- **Environment:** *(unset)*

## Changes

Four surgical edits inside the `publish-nuget:` job (lines ~672–730 of `release.yaml`):

1. Replaced `permissions: {}` with `permissions: { id-token: write, contents: read }` — required for OIDC token issuance.
2. Removed the `Validate NuGet API key` step (no longer applicable).
3. Added a `NuGet/login@v1` step immediately before the push — exchanges the OIDC token for a 1-hour NuGet API key.
4. Changed `NUGET_API_KEY` env source on the Publish step from `secrets.NUGET_API_KEY` → `steps.nuget-login.outputs.NUGET_API_KEY`.

Also updated the canonical header comment above `publish-nuget:` to describe the trusted-publishing model.

The `dotnet nuget push … --api-key $env:NUGET_API_KEY …` command itself is unchanged.

## After merge

1. **Delete the stale `NUGET_API_KEY` repository secret** (Settings → Secrets and variables → Actions).
2. Re-fire the release — either delete + recreate the tag/release, or bump patch and cut a fresh release.