### PR TITLE
ci(inspectcode): add .DotSettings noise-floor profile (refs #133)

### DIFF
--- a/ETL-Transformers.slnx.DotSettings
+++ b/ETL-Transformers.slnx.DotSettings
@@ -1,0 +1,41 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<!--
+	  ReSharper InspectCode noise-floor profile (solution team-shared layer).
+
+	  Loaded automatically by `jb inspectcode ETL-Transformers.slnx` in the
+	  pr.yaml `inspectcode` job. Purpose: silence InspectCode inspections that
+	  merely DUPLICATE findings the existing Roslyn analyzer stack already
+	  reports (.editorconfig + Roslynator + SonarAnalyzer + Meziantou +
+	  AsyncFixer + VSTHRD + BannedApiAnalyzers), so Code Scanning shows
+	  InspectCode's UNIQUE findings (data-flow, dead-code, structural) rather
+	  than double-reporting style/naming/import issues.
+
+	  Scope is deliberately conservative — only pure style / naming / import
+	  inspections that another tool authoritatively owns are set to
+	  DO_NOT_SHOW. Correctness, data-flow, and dead-code inspections are left
+	  at their defaults. Tune further (per rule ID, not category) after the
+	  first InspectCode run lands a clean baseline on main; see issue #133.
+	-->
+
+	<!-- Import ordering / redundancy — owned by IDE0005 + ImplicitUsings.
+	     Also suppresses the net10 ImplicitUsings false positive where SDK
+	     implicit globals make explicit usings look "redundant". -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Naming — owned by IDE1006 + .editorconfig naming rules. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- `this.` qualification — owned by .editorconfig dotnet_style_qualification_*. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Predefined-type style (int vs System.Int32) — owned by .editorconfig
+	     dotnet_style_predefined_type_*. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BuiltInTypeReferenceStyle/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BuiltInTypeReferenceStyleForMemberAccess/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Member-modifier arrangement / order — owned by .editorconfig
+	     dotnet_style_require_accessibility_modifiers + modifier order. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeModifiersOrder/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
Part of the vNext stacked wave. **Base: `vNext`.**

## What
Adds `ETL-Transformers.slnx.DotSettings` — the solution team-shared ReSharper settings layer that `jb inspectcode ETL-Transformers.slnx` auto-loads in the `inspectcode` CI job.

## Why
The job added in #144 uploads all InspectCode findings to Code Scanning. Many overlap the existing Roslyn analyzer stack (`.editorconfig` + Roslynator + SonarAnalyzer + Meziantou + AsyncFixer + VSTHRD + BannedApiAnalyzers). This profile silences **only** the style/naming/import inspections another tool authoritatively owns, so Code Scanning shows InspectCode's *unique* value (data-flow, dead-code, structural) instead of double-reporting. Includes the net10 ImplicitUsings redundant-using false positive seen fleet-wide.

Scope is deliberately conservative — correctness/data-flow/dead-code inspections stay at defaults. Tune per rule ID after the first clean run on main.

## Scope note (does not close #133)
This is the `.DotSettings` acceptance item only. Two items remain and are **not** PR-shaped:
- Add "ReSharper InspectCode" as a **required status check** on the `main` ruleset (branch-protection config).
- Canonical `.DotSettings` should land in `repo-template` first — tracked in Chris-Wolfgang/repo-template#443.

Also note: the #144 trusted-config reconciliation deletes PR-added `.DotSettings` during InspectCode CI, so this profile takes effect only once vNext reaches main (intended security behavior).

Refs #133