### PR TITLE
build: select gitleaks arch for Linux arm64 (closes #148)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,17 +295,17 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            # gitleaks ships separate darwin / linux builds, and on macOS we
-            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
-            # Without this branch the macOS path would download the Linux
-            # tarball and either fail to install or install an incompatible
-            # binary.
+            # gitleaks ships separate darwin / linux builds, and each also
+            # splits x64 (Intel/AMD) vs arm64. Detect the process architecture
+            # for BOTH so an arm64 host (Apple Silicon, or Linux arm64 CI /
+            # Raspberry Pi / AWS Graviton) downloads the matching tarball
+            # instead of an incompatible binary.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
             if ($IsMacOS) {
-                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
                 $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
             }
             else {
-                $archive = "gitleaks_${version}_linux_x64.tar.gz"
+                $archive = "gitleaks_${version}_linux_${arch}.tar.gz"
             }
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin


### PR DESCRIPTION
Part of the vNext stacked wave. **Base: `chore/inspectcode-dotsettings` (PR #151)** — review/merge that first.

## What
The Linux branch of the gitleaks auto-install in `scripts/build-pr.ps1` hardcoded `gitleaks_${version}_linux_x64.tar.gz`. On an arm64 Linux host (AWS Graviton CI, Raspberry Pi, arm64 dev containers) that fetches an incompatible binary.

## Fix
Hoist the `OSArchitecture`-based `$arch` detection the macOS branch already uses so **both** darwin and linux select `x64` vs `arm64`. gitleaks publishes matching `linux_arm64` / `darwin_arm64` release assets.

No workflow sync needed — CI's Secrets Scan uses the gitleaks action (which resolves its own arch); this is the local build-script parity fix only.

Closes #148