### PR TITLE
docs: add migration-guide convention + template (closes #96)

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,23 @@
+# Migration guides
+
+Per-major-version upgrade guides for `Wolfgang.Etl.Transformers`.
+
+The library is currently **0.x** — no major version with breaking changes has
+shipped yet, so there are no migration guides to list here. This folder and its
+[template](TEMPLATE-major-version-migration.md) exist so the convention is ready
+the moment the first breaking release is prepared.
+
+## Convention
+
+- When a release introduces breaking changes (0.x → next 0.x during pre-1.0, or
+  any `X.0` major after 1.0), copy `TEMPLATE-major-version-migration.md` to
+  `vX-to-vY.md` and fill it in **during release prep** — not after the release
+  ships. Retrofitting a migration guide after consumers have already hit the
+  break is far more expensive.
+- Each guide inventories every breaking change with a before/after code sample
+  and the reasoning (link the corresponding [ADR](../adr/) where one exists).
+- Link the finished guide from the GitHub Release notes for that version.
+
+## Guides
+
+_None yet — the first lands with the first breaking release._

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,59 @@
+# Migrating from vX to vY
+
+> Copy this file to `vX-to-vY.md` when preparing a major release and fill in
+> every section. Delete guidance blockquotes (like this one) as you go. Link
+> the finished guide from the GitHub Release notes for vY.
+
+`Wolfgang.Etl.Transformers` vY contains breaking changes relative to vX. This
+guide lists every break, why it changed, and how to update your code.
+
+## At a glance
+
+| Area | vX | vY | Action |
+| --- | --- | --- | --- |
+| _e.g._ `WhereTransformer<T>` ctor | `new WhereTransformer<T>(pred)` | `new WhereTransformer<T>(pred, options)` | Pass `TransformerOptions.Default` |
+
+## Breaking changes
+
+> One subsection per break. Keep them ordered by how likely a consumer is to
+> hit them (most common first).
+
+### 1. <short title of the change>
+
+**What changed** — <one or two sentences.>
+
+**Why** — <the motivating reason: correctness, API consistency, perf, removing
+a footgun. Link the ADR in `docs/adr/` if one exists.>
+
+**Before (vX)**
+
+```csharp
+// old code
+```
+
+**After (vY)**
+
+```csharp
+// new code
+```
+
+## Deprecations (not yet removed)
+
+> APIs still present in vY but marked `[Obsolete]`, with the version they are
+> scheduled for removal. Consumers can migrate off these before the next major.
+
+| API | Replacement | Removed in |
+| --- | --- | --- |
+| _e.g._ `OldMethodAsync` | `NewMethodAsync` | vZ |
+
+## Deprecation timeline
+
+- **vX** — <API introduced / last version before the break>.
+- **vY** — <break lands; old API removed or `[Obsolete]`>.
+- **vZ (planned)** — <obsolete APIs removed>.
+
+## Need help?
+
+Open a [discussion](https://github.com/Chris-Wolfgang/ETL-Transformers/discussions)
+or [issue](https://github.com/Chris-Wolfgang/ETL-Transformers/issues) if a
+migration step is unclear.


### PR DESCRIPTION
Part of the vNext wave (independent, targets `vNext`). Docs-only.

## What
Adds `docs/migrations/` with:
- `TEMPLATE-major-version-migration.md` — sections for a breaking-change inventory, before/after code samples, deprecation table, and deprecation timeline.
- `README.md` — the convention: write the guide **during** release prep (not after), inventory every break with reasoning (link the ADR), and link the guide from the GitHub Release notes.

No major/breaking release has shipped (library is 0.2.1), so there are no guides yet — this just makes the convention ready for the first one. Cheap to file proactively, expensive to retrofit.

Closes #96