### PR TITLE
docs: add Architecture Decision Records (closes #97)

### DIFF
--- a/docs/adr/0001-async-first-banned-symbols.md
+++ b/docs/adr/0001-async-first-banned-symbols.md
@@ -1,0 +1,45 @@
+# ADR-0001: Async-first enforcement via BannedSymbols.txt
+
+- **Status**: Accepted
+- **Date**: 2026-07-20
+- **Deciders**: @Chris-Wolfgang
+
+## Context
+
+ETL work is dominated by I/O — reading sources, writing destinations, awaiting
+downstream systems. The transformers in this library sit in the middle of an
+`IAsyncEnumerable<T>` pipeline whose whole point is non-blocking streaming.
+
+Blocking synchronous APIs (`Task.Wait()`, `Task<T>.Result`,
+`GetAwaiter().GetResult()`, `Thread.Sleep`, synchronous `File`/`Stream` I/O,
+`Parallel.For`/`ForEach`, blocking `Console` reads) are easy to reach for by
+habit, compile without complaint, and then cause thread-pool starvation or
+outright deadlock when they appear on an async path — especially under a
+single-threaded synchronization context. Code review alone does not reliably
+catch them.
+
+## Decision
+
+We enforce the async-first rule mechanically with
+`Microsoft.CodeAnalysis.BannedApiAnalyzers` and a repo-level
+[`BannedSymbols.txt`](../../BannedSymbols.txt) that bans the blocking APIs
+outright, each with a documented async replacement. Violations are build errors
+(warnings-as-errors in Release), so a blocking call cannot merge.
+
+## Consequences
+
+- **Positive** — the pipeline stays non-blocking by construction; a whole class
+  of deadlock/starvation bugs is impossible to introduce. The reason for each
+  ban travels with the ban (the reason column doubles as the fix hint).
+- **Negative / accepted trade-off** — the ban list is maintained by hand and
+  must be kept in sync across the repo family; genuinely-needed synchronous
+  calls (rare) require an explicit, reviewed `#pragma` suppression.
+- **Neutral** — the list is deliberately broad (network, serialization, DateTime
+  anti-patterns) beyond the strict async concern, acting as a general
+  "don't-use-this" gate.
+
+## Alternatives considered
+
+- **Rely on code review / AsyncFixer only** — AsyncFixer catches some patterns
+  but not all banned APIs, and review misses them under time pressure. A hard
+  build gate is deterministic.

--- a/docs/adr/0002-notnull-constraint-on-record-type.md
+++ b/docs/adr/0002-notnull-constraint-on-record-type.md
@@ -1,0 +1,41 @@
+# ADR-0002: `where T : notnull` on transformer record types
+
+- **Status**: Accepted
+- **Date**: 2026-07-20
+- **Deciders**: @Chris-Wolfgang
+
+## Context
+
+Every transformer flows a stream of records (`T`, `TSource`, `TDestination`)
+through `IAsyncEnumerable`. The base types in `Wolfgang.Etl.Abstractions`
+constrain their record type parameters to `notnull`, and the transformers here
+build on that base.
+
+A `null` record in an ETL stream is almost always a defect: it is ambiguous
+(end-of-stream? skipped row? genuine value?), and it forces every downstream
+transformer and loader to null-check the item on the hot path. Allowing `T` to
+be a nullable reference type would push that ambiguity through the whole
+pipeline.
+
+## Decision
+
+All transformer type parameters carry `where T : notnull` (inherited from the
+Abstractions base classes). Records in the stream are non-null by contract;
+"no value" is represented by the stream simply not yielding an item, not by
+yielding `null`.
+
+## Consequences
+
+- **Positive** — downstream stages never have to defend against `null` items;
+  the nullable-reference-type analysis stays clean end-to-end; the "no value"
+  case has one unambiguous representation (yield nothing).
+- **Negative / accepted trade-off** — consumers cannot use a nullable reference
+  type (`string?`) or `Nullable<T>` directly as the record type; they wrap the
+  optionality in the value shape or filter nulls out at the extractor edge.
+- **Neutral** — matches the constraint the rest of the ETL family already
+  imposes, so records compose across libraries without constraint mismatches.
+
+## Alternatives considered
+
+- **Leave `T` unconstrained** — would compile, but reintroduces null ambiguity
+  and per-stage null checks, and would diverge from the Abstractions contract.

--- a/docs/adr/0003-multi-tfm-targeting.md
+++ b/docs/adr/0003-multi-tfm-targeting.md
@@ -1,0 +1,40 @@
+# ADR-0003: Broad multi-target-framework matrix (net462 → net10.0)
+
+- **Status**: Accepted
+- **Date**: 2026-07-20
+- **Deciders**: @Chris-Wolfgang
+
+## Context
+
+The library targets a wide framework matrix:
+`net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0`.
+
+ETL glue code lives in long-lived line-of-business systems, many of which are
+still on .NET Framework 4.x and cannot move to modern .NET on the timeline of a
+dependency upgrade. Restricting to `net8.0+` would make the library unusable for
+exactly the integration-heavy codebases that most need reusable transformers.
+
+## Decision
+
+We target the full matrix down to `net462`, with `netstandard2.0` as the broad
+floor and explicit modern TFMs above it. `SuppressTfmSupportBuildWarnings` is
+set for the older targets, and `TargetFrameworks` is kept on a **single line**
+in the csproj because CI greps it.
+
+## Consequences
+
+- **Positive** — the library drops into .NET Framework 4.x apps and modern .NET
+  apps alike without a shim; consumers pick the best TFM their app resolves to.
+- **Negative / accepted trade-off** — more build/test surface (every TFM is
+  built and tested), occasional per-TFM polyfills and `#if` guards, and API
+  choices constrained to what `netstandard2.0` can express unless guarded.
+- **Neutral** — the async streaming surface relies on
+  `Microsoft.Bcl.AsyncInterfaces` to make `IAsyncEnumerable<T>` available on the
+  down-level targets.
+
+## Alternatives considered
+
+- **`net8.0`+ only** — simpler build, smaller test matrix, but excludes the
+  .NET Framework consumers this library is meant to serve.
+- **`netstandard2.0` only** — one TFM, but forgoes modern-runtime optimizations
+  and newer BCL surface available on `net6.0+`.

--- a/docs/adr/0004-assemblyversion-pinned-to-minor.md
+++ b/docs/adr/0004-assemblyversion-pinned-to-minor.md
@@ -1,0 +1,47 @@
+# ADR-0004: Pin `AssemblyVersion` to `major.minor.0.0`
+
+- **Status**: Accepted
+- **Date**: 2026-07-20
+- **Deciders**: @Chris-Wolfgang
+
+## Context
+
+The csproj carries two distinct versions:
+
+```xml
+<Version>0.2.1</Version>          <!-- NuGet package + informational version -->
+<AssemblyVersion>0.2.0.0</AssemblyVersion>
+```
+
+On .NET Framework, the CLR binds by the strong-name `AssemblyVersion`. If
+`AssemblyVersion` changed on every patch release, a consumer that compiled
+against `0.2.0` would need a binding redirect to load `0.2.1` at runtime — a
+notorious source of "could not load file or assembly … version" failures in
+LOB apps that pull the library in transitively.
+
+## Decision
+
+`AssemblyVersion` is pinned to `major.minor.0.0` and only bumped on a
+minor/major release. The patch component lives in the NuGet `Version` (and
+`FileVersion`), which do **not** participate in CLR binding. Patch releases are
+therefore binary drop-in replacements: `0.2.0`, `0.2.1`, `0.2.2` all present
+`AssemblyVersion 0.2.0.0`.
+
+## Consequences
+
+- **Positive** — patch upgrades need no binding redirects on .NET Framework;
+  transitive consumers pick up fixes without recompiling or editing config.
+- **Negative / accepted trade-off** — two assemblies with the same
+  `AssemblyVersion` but different `FileVersion` can coexist confusingly at
+  diagnosis time; you must read `FileVersion`/`InformationalVersion` to know the
+  exact build. A genuinely binary-breaking change **must** be released as at
+  least a minor bump so `AssemblyVersion` moves.
+- **Neutral** — irrelevant to `net5.0+`, which does not bind on
+  `AssemblyVersion`; the pin exists for the .NET Framework targets (see
+  [ADR-0003](0003-multi-tfm-targeting.md)).
+
+## Alternatives considered
+
+- **Let `AssemblyVersion` track the full `Version`** — strictest binding, but
+  forces a binding redirect (or recompile) on every patch for .NET Framework
+  consumers.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,28 @@
+# ADR-NNNN: <short title of decision>
+
+- **Status**: Proposed | Accepted | Superseded by [ADR-XXXX](XXXX-....md) | Deprecated
+- **Date**: YYYY-MM-DD
+- **Deciders**: @Chris-Wolfgang
+
+## Context
+
+What is the problem or force that motivates this decision? What constraints
+apply (framework support, performance, API compatibility, tooling)? State the
+facts neutrally — the decision follows in the next section.
+
+## Decision
+
+The choice that was made, stated in one or two sentences. "We will …".
+
+## Consequences
+
+What becomes easier or harder as a result. Include the trade-offs accepted, not
+just the upside — the value of an ADR is that it records what was given up.
+
+- **Positive** — …
+- **Negative / accepted trade-off** — …
+- **Neutral** — …
+
+## Alternatives considered
+
+- **<alternative>** — why it was not chosen.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+Short records of the non-obvious design decisions in
+`Wolfgang.Etl.Transformers` — the context, the choice, and the trade-offs
+accepted — so the reasoning survives past the PR that introduced it.
+
+New ADRs land **alongside the PR** that introduces the corresponding decision
+and are part of that review. Copy [`TEMPLATE.md`](TEMPLATE.md) to the next
+`NNNN-title.md`, and add a row below. Never delete an ADR — supersede it (mark
+the old one `Superseded by ADR-XXXX` and add the replacement).
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-async-first-banned-symbols.md) | Async-first enforcement via BannedSymbols.txt | Accepted |
+| [0002](0002-notnull-constraint-on-record-type.md) | `where T : notnull` on transformer record types | Accepted |
+| [0003](0003-multi-tfm-targeting.md) | Broad multi-TFM matrix (net462 → net10.0) | Accepted |
+| [0004](0004-assemblyversion-pinned-to-minor.md) | Pin `AssemblyVersion` to `major.minor.0.0` | Accepted |


### PR DESCRIPTION
Part of the vNext wave (independent, targets `vNext`). Docs-only.

## What
Adds `docs/adr/` with a MADR-style `TEMPLATE.md`, an `index.md` (all ADRs + status), and **four retroactive ADRs** documenting this repo's actual non-obvious decisions:

- **0001** — Async-first enforcement via `BannedSymbols.txt` (why blocking APIs are hard build errors).
- **0002** — `where T : notnull` on transformer record types (why nulls aren't allowed in the stream).
- **0003** — Broad multi-TFM matrix net462→net10.0 (why still support .NET Framework 4.x).
- **0004** — `AssemblyVersion` pinned to `major.minor.0.0` while `Version` is `0.2.1` (binary drop-in patches without binding redirects).

Convention documented in the index: new ADRs land alongside the PR that introduces the decision; supersede, never delete.

Closes #97