### PR TITLE
docs(security): add Release path & compromise scope appendix (closes #98)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,13 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/ETL-Transformers`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: no known Wolfgang.* repository takes a package dependency on this library today — it is a leaf library consumed directly by end-user ETL pipelines. Unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Etl.Transformers` on nuget.org — https://www.nuget.org/packages/Wolfgang.Etl.Transformers/. This repo ships a single package.


### PR DESCRIPTION
Part of the vNext wave (independent, targets `vNext`). Docs-only, no version bump.

## What
Appends the canonical **Release path & compromise scope** section to `SECURITY.md` (shape from Etl-DbClient #240), all five bullets filled in:
- **Release path** — OIDC / NuGet Trusted Publishing via `NuGet/login@v1`; no long-lived API key.
- **Fallback** — none; a compromise is GitHub-account-level (OIDC identity `Chris-Wolfgang/ETL-Transformers`).
- **Owner** — @Chris-Wolfgang.
- **Downstream consumers** — no known Wolfgang.* dependents (leaf library); external nuget.org consumers may exist.
- **Package coordinates** — `Wolfgang.Etl.Transformers` (single package).

No `[fill in]` placeholders remain; generic incident-response steps intentionally not duplicated.

Closes #98