### PR TITLE
ci: adopt OSSF Scorecard (closes #99)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: OSSF Scorecard
+
+# Scores this repository's SECURITY posture (branch protection, pinned actions,
+# token permissions, dangerous-workflow patterns, vulnerability response, …)
+# against ~20 OpenSSF best practices and produces a 0-10 score. Complementary to
+# CodeQL/SAST: Scorecard grades the repo *configuration*, not the code. Results
+# upload to the Security tab (alongside CodeQL alerts) and publish to the public
+# Scorecard API that backs the README badge.
+#
+# Score floor policy: see docs/ossf-scorecard.md.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'   # Mondays 07:20 UTC
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Read-all at the top; the analysis job elevates only what it needs.
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      id-token: write          # publish results to the public Scorecard API
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the public Scorecard API so the README badge resolves.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A collection of generic, composable transformers for ETL pipelines built on [Wol
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Etl.Transformers.svg)](https://www.nuget.org/packages/Wolfgang.Etl.Transformers)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/ETL-Transformers)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Chris-Wolfgang/ETL-Transformers/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Chris-Wolfgang/ETL-Transformers)
 
 ---
 

--- a/docs/ossf-scorecard.md
+++ b/docs/ossf-scorecard.md
@@ -1,0 +1,30 @@
+# OpenSSF Scorecard
+
+[`scorecard.yml`](../.github/workflows/scorecard.yml) runs the
+[OpenSSF Scorecard](https://github.com/ossf/scorecard) action weekly (and on
+push to `main` / branch-protection-rule changes). Scorecard grades the
+repository's **security configuration** — branch protection, SHA-pinned
+actions, least-privilege token permissions, dangerous-workflow patterns,
+vulnerability-response time, and ~15 other checks — and produces a 0–10 score.
+
+It is complementary to CodeQL/SAST, which scan the *code*; Scorecard scans the
+*repo setup*. Results upload to **Security → Code scanning** alongside CodeQL
+alerts, and publish to the public Scorecard API that backs the README badge.
+
+## Score floor
+
+- **Threshold: 7.5 / 10.** If a Scorecard run drops the aggregate score below
+  7.5, that is a signal for reviewer attention — note the regression and its
+  cause in `CHANGELOG.md` (under a `### Security` entry) and open a follow-up to
+  restore it, or record why the lower score is accepted.
+- Individual check failures that are **known and accepted** (e.g. an ecosystem
+  limitation) should be documented here so they aren't re-investigated each run.
+
+## Baseline
+
+The initial score is established by the first scheduled/`main` run after this
+workflow lands (Scorecard does not run on pull requests — it needs the default
+branch and repo metadata). Record the baseline score and any accepted findings
+in this section once that first run completes.
+
+_Baseline: pending first run on `main`._


### PR DESCRIPTION
Part of the vNext wave (independent, targets `vNext`).

## What
Adds `.github/workflows/scorecard.yml` — the OpenSSF Scorecard action on a weekly schedule + push to `main` + `branch_protection_rule`. It scores the repo's *security configuration* (branch protection, pinned actions, token permissions, dangerous-workflow patterns, …) 0–10, uploads SARIF to **Security → Code scanning**, and publishes to the public Scorecard API.

- **README badge** — live OpenSSF Scorecard badge.
- **`docs/ossf-scorecard.md`** — documents the **7.5 score floor** (regressions noted in CHANGELOG under `### Security`) and a baseline-pending note.

## Notes
Scorecard runs on `main`/schedule, **not** on PRs (it needs the default branch + repo metadata), so this PR's CI won't execute it — the baseline is captured on the first run after merge. Actions SHA-pinned (checkout, scorecard-action v2.4.0, upload-artifact); `codeql-action/upload-sarif@v4` tag matches existing repo usage.

Closes #99