### PR TITLE
ci: finish action pinning missed by #161 (license-audit, scorecard)

### DIFF
--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write          # publish results to the public Scorecard API
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Follow-up to #161. Because #161 branched before #153 (license-audit) and #157 (scorecard) merged, it didn't cover their workflows. On `vNext` they still carry:

- `license-audit.yaml` — `actions/checkout@9c091bb` with a stale `# v7` comment (v7 now resolves to `3d3c42e`).
- `scorecard.yml` — same stale checkout **plus** an unpinned `github/codeql-action/upload-sarif@v4`.

This repins:
- both `checkout` → `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`
- scorecard's `upload-sarif` → `7188fc363630916deb702c7fdcf4e481b751f97a # v4` (verified `v4 → 7188fc3`)

After this, **every** workflow's action refs are SHA-pinned with matching version comments, clearing the remaining zizmor `unpinned-uses` / mismatched-comment findings. (`stryker.yaml`'s `upload-artifact@043fb46 # v7` is validly pinned — left as-is.)

Once this + #158 land, the zizmor `unpinned-uses` policy can flip from `ref-pin` to `hash-pin`.