### PR TITLE
build: bump Wolfgang.Etl.Abstractions 0.15.0 → 0.16.0 (refs #150)

### DIFF
--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**PR 1 of 2** for #150 (EtlPipeline operator extensions). Base: `vNext`.

## What
Bumps the `Wolfgang.Etl.Abstractions` PackageReference from **0.15.0 → 0.16.0** — the version (now published to nuget.org) that ships the `EtlPipeline` core: `IEtlPipeline<T>`, `EtlPipeline.Create()`, `Through(...)`, `To(...)`, `AsAsyncEnumerable()`. This is the prerequisite the #150 operator layer builds on.

## Verification
- Full solution builds clean in Release — **no** `Microsoft.Bcl.*` / `System.Linq.Async` downgrade cascade (NU1605).
- 262 unit tests pass (net10.0).

PR 2 (`EtlPipelineOperatorExtensions` + tests + README) stacks on this branch.

Refs #150