### PR TITLE
test: culture-invariance matrix (closes #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
+
 ### Changed
 
 ### Deprecated

--- a/docs/globalization.md
+++ b/docs/globalization.md
@@ -1,0 +1,30 @@
+# Globalization / culture invariance
+
+`Wolfgang.Etl.Transformers` is **culture-invariant**: no public method's behavior
+depends on `CultureInfo.CurrentCulture` / `CurrentUICulture`.
+
+## Why
+
+The transformers operate on generic `T` and perform no formatting or parsing of
+strings, dates, or numbers. The only comparison points are equality and keying:
+
+- `DistinctTransformer<T>` and `DistinctByTransformer<TSource,TKey>` default to
+  `EqualityComparer<T>.Default`, which is **ordinal** for `string` (and
+  structural for other types) — not culture-sensitive.
+- When a caller supplies an `IEqualityComparer<T>`/`IEqualityComparer<TKey>`, the
+  comparison semantics are the caller's choice. Passing a culture-sensitive
+  comparer (e.g. `StringComparer.CurrentCultureIgnoreCase`) makes *that call*
+  culture-sensitive by the caller's intent — the library does not impose it.
+
+## Allowlist of intentionally culture-sensitive public methods
+
+**None.** No public method in this library is intended to vary by culture.
+
+## Enforcement
+
+[`GlobalizationInvarianceTests`](../tests/Wolfgang.Etl.Transformers.Tests.Unit/Globalization/GlobalizationInvarianceTests.cs)
+runs a representative set of operations under `en-US`, `tr-TR`, `de-DE`, `zh-CN`,
+`ar-SA`, and `ja-JP` (swapping both `CurrentCulture` and `CurrentUICulture` and
+restoring them after each test), asserting identical, ordinal results in every
+culture. If a future change introduces culture-sensitive behavior, add it to the
+allowlist above and cover it explicitly.

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/Globalization/GlobalizationInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/Globalization/GlobalizationInvarianceTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit.Globalization;
+
+/// <summary>
+/// Runs a representative set of transformer operations under hostile cultures
+/// (Turkish dotted-I, German decimal comma, Chinese collation, Arabic RTL/digit
+/// shaping, Japanese full-width) to prove the library is culture-invariant.
+/// </summary>
+/// <remarks>
+/// The transformers own no culture-sensitive behavior: equality/keying uses
+/// <see cref="EqualityComparer{T}.Default"/> (ordinal for <see cref="string"/>),
+/// and any comparer is caller-supplied. There is no formatting or parsing of
+/// strings, dates, or numbers in the library. See <c>docs/globalization.md</c>
+/// for the (empty) allowlist of intentionally culture-sensitive public methods.
+/// Each test swaps both <see cref="CultureInfo.CurrentCulture"/> and
+/// <see cref="CultureInfo.CurrentUICulture"/> and restores them afterwards.
+/// </remarks>
+public class GlobalizationInvarianceTests
+{
+    // The four Turkish "I" glyphs are the canonical culture-casing trap: under
+    // tr-TR, culture-aware case folding maps them differently than en-US.
+    // Ordinal comparison (the library default) keeps all four distinct in EVERY
+    // culture — that invariance is what these tests assert.
+    private static readonly string[] TurkishIVariants = { "I", "ı", "i", "İ" };
+
+    public static IEnumerable<object[]> Cultures()
+    {
+        yield return new object[] { "en-US" };
+        yield return new object[] { "tr-TR" };
+        yield return new object[] { "de-DE" };
+        yield return new object[] { "zh-CN" };
+        yield return new object[] { "ar-SA" };
+        yield return new object[] { "ja-JP" };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public async Task Distinct_default_comparer_is_ordinal_under_every_culture(string culture)
+    {
+        await UnderCulture(culture, async () =>
+        {
+            var result = await CollectAsync(new DistinctTransformer<string>().TransformAsync(ToAsync(TurkishIVariants)));
+
+            // Ordinal: all four glyphs are distinct regardless of the ambient culture.
+            Assert.Equal(TurkishIVariants, result);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public async Task Distinct_ordinal_ignore_case_comparer_is_stable_under_every_culture(string culture)
+    {
+        await UnderCulture(culture, async () =>
+        {
+            var result = await CollectAsync
+            (
+                new DistinctTransformer<string>(StringComparer.OrdinalIgnoreCase)
+                    .TransformAsync(ToAsync(new[] { "I", "i", "STRASSE", "strasse" }))
+            );
+
+            // OrdinalIgnoreCase folds case invariantly: "I"/"i" collapse, and the
+            // German "ß" is NOT expanded to "ss" (that would be culture/linguistic).
+            Assert.Equal(new[] { "I", "STRASSE" }, result);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public async Task DistinctBy_default_key_comparer_is_ordinal_under_every_culture(string culture)
+    {
+        await UnderCulture(culture, async () =>
+        {
+            var items = new[] { "Igloo", "ıce", "iron", "İsland" };
+
+            var result = await CollectAsync
+            (
+                new DistinctByTransformer<string, string>(s => s.Substring(0, 1))
+                    .TransformAsync(ToAsync(items))
+            );
+
+            // Keys are the four Turkish "I" glyphs — all distinct ordinally, so
+            // every item survives, in every culture.
+            Assert.Equal(items, result);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public async Task Pipeline_output_is_identical_across_cultures(string culture)
+    {
+        var source = new[] { "apple", "Apricot", "banana", "Avocado", "cherry" };
+
+        // Baseline under the invariant culture.
+        List<string> baseline = null!;
+        await UnderCulture("", async () =>
+        {
+            baseline = await RunPipeline(source);
+        });
+
+        await UnderCulture(culture, async () =>
+        {
+            var actual = await RunPipeline(source);
+            Assert.Equal(baseline, actual);
+        });
+    }
+
+    private static async Task<List<string>> RunPipeline(string[] source)
+    {
+        var whereA = new WhereTransformer<string>(s => s.Length > 4);
+        var select = new SelectTransformer<string, string>(s => s.ToUpperInvariant());
+        var distinct = new DistinctTransformer<string>(StringComparer.Ordinal);
+
+        return await CollectAsync
+        (
+            distinct.TransformAsync(select.TransformAsync(whereA.TransformAsync(ToAsync(source))))
+        );
+    }
+
+    private static async Task UnderCulture(string cultureName, Func<Task> body)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var culture = string.IsNullOrEmpty(cultureName)
+                ? CultureInfo.InvariantCulture
+                : CultureInfo.GetCultureInfo(cultureName);
+
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+
+            await body().ConfigureAwait(false);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+}


### PR DESCRIPTION
First of the thorough-review stacked PRs (base `main`).

## What
`GlobalizationInvarianceTests` runs a representative set of transformer operations under **en-US, tr-TR, de-DE, zh-CN, ar-SA, ja-JP** — swapping both `CurrentCulture` and `CurrentUICulture` per test and restoring them — asserting **ordinal, culture-invariant** results everywhere. Covers the canonical traps: Turkish dotted-I distinctness, `ß`→`ss` non-expansion under `OrdinalIgnoreCase`, and identical pipeline output across cultures.

`docs/globalization.md` documents the allowlist of intentionally culture-sensitive public methods: **none** — the transformers do no formatting/parsing; equality/keying is `EqualityComparer<T>.Default` (ordinal) and comparers are caller-supplied.

## Verification
24 tests pass (6 cultures × 4 checks); clean Release build.

Closes #92