### PR TITLE
test: property-based fuzzing (CsCheck) + scheduled fuzz workflow (closes #76)

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,87 @@
+name: Fuzz
+
+# Continuous property-based fuzzing. The same properties in
+# tests/Wolfgang.Etl.Transformers.Tests.Fuzz run a small case count in the normal
+# PR pass (seconds); here CsCheck_Iter drives a large budget (100k cases per
+# property) to surface edge cases the short pass misses. A failing property
+# prints a reproducible seed; the run's results are uploaded and an issue is filed.
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'   # Sundays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # CsCheck honours this: 100,000 randomized cases per property (the #76 target).
+  CsCheck_Iter: '100000'
+
+jobs:
+  fuzz:
+    name: Property fuzzing
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write   # auto-file an issue when a property fails
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect fuzz project
+        id: detect
+        run: |
+          if git ls-files 'tests/**/*.Tests.Fuzz.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No fuzz project found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run property fuzzing
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          proj="$(git ls-files 'tests/**/*.Tests.Fuzz.csproj' | head -n1)"
+          dotnet test "$proj" -c Release \
+            --logger "trx;LogFileName=fuzz.trx" \
+            --results-directory ./fuzz-results
+
+      # The .trx captures the failing property and CsCheck's reproducible seed,
+      # so the next short-pass run can be pinned to it as a deterministic regression.
+      - name: Upload fuzz results
+        if: always() && steps.detect.outputs.found == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-results
+          path: ./fuzz-results
+          if-no-files-found: ignore
+
+      - name: File an issue on failure
+        if: failure() && steps.detect.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Fuzz: property counter-example ($(date -u +%Y-%m-%d))"
+          # Avoid duplicate spam — only open a new issue if none is already open.
+          if gh issue list --state open --search "in:title Fuzz: property counter-example" --json number --jq 'length' | grep -qx 0; then
+            gh issue create \
+              --title "$title" \
+              --label thorough-review \
+              --body "A property in the Fuzz suite failed on the scheduled run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Download the \`fuzz-results\` artifact for the failing property and CsCheck's reproducible seed, then reproduce locally with \`CsCheck_Seed=<seed> dotnet test tests/Wolfgang.Etl.Transformers.Tests.Fuzz\`."
+          else
+            echo "An open fuzz counter-example issue already exists — not filing a duplicate."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
+
 ### Changed
 
 ### Deprecated

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -46,6 +46,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj" />
+    <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj" />
   </Folder>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/TransformerEquivalenceProperties.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/TransformerEquivalenceProperties.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CsCheck;
+using Xunit;
+
+namespace Wolfgang.Etl.Transformers.Tests.Fuzz;
+
+/// <summary>
+/// Property-based tests: each transformer must be equivalent to its
+/// <see cref="System.Linq"/> reference over randomized inputs. CsCheck generates
+/// the cases and shrinks any counter-example to its minimal form. The per-case
+/// count is small in the normal test pass and large under fuzz.yaml (via the
+/// <c>CsCheck_Iter</c> / <c>CsCheck_Time</c> environment variables).
+/// </summary>
+public class TransformerEquivalenceProperties
+{
+    private static readonly Gen<List<int>> IntLists = Gen.Int[-10, 10].List[0, 50];
+
+    [Fact]
+    public async Task Where_is_equivalent_to_Linq_Where() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.Where(IsEven).ToList();
+            var actual = await Collect(new WhereTransformer<int>(IsEven).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task Select_is_equivalent_to_Linq_Select() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.Select(Times10).ToList();
+            var actual = await Collect(new SelectTransformer<int, long>(Times10).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task SelectMany_is_equivalent_to_Linq_SelectMany() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.SelectMany(PlusMinus).ToList();
+            var actual = await Collect(new SelectManyTransformer<int, int>(PlusMinus).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task Distinct_is_equivalent_to_Linq_Distinct() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.Distinct().ToList();
+            var actual = await Collect(new DistinctTransformer<int>().TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task DistinctBy_is_equivalent_to_Linq_DistinctBy() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.DistinctBy(Mod3).ToList();
+            var actual = await Collect(new DistinctByTransformer<int, int>(Mod3).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task Take_is_equivalent_to_Linq_Take() =>
+        await ListAndCount().SampleAsync(async pair =>
+        {
+            var (list, n) = pair;
+            var expected = list.Take(n).ToList();
+            var actual = await Collect(new TakeTransformer<int>(n).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task Skip_is_equivalent_to_Linq_Skip() =>
+        await ListAndCount().SampleAsync(async pair =>
+        {
+            var (list, n) = pair;
+            var expected = list.Skip(n).ToList();
+            var actual = await Collect(new SkipTransformer<int>(n).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task TakeWhile_is_equivalent_to_Linq_TakeWhile() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.TakeWhile(IsNonNegative).ToList();
+            var actual = await Collect(new TakeWhileTransformer<int>(IsNonNegative).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task SkipWhile_is_equivalent_to_Linq_SkipWhile() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var expected = list.SkipWhile(IsNonNegative).ToList();
+            var actual = await Collect(new SkipWhileTransformer<int>(IsNonNegative).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual);
+        });
+
+    [Fact]
+    public async Task Chunk_is_equivalent_to_Linq_Chunk() =>
+        await ListAndSize().SampleAsync(async pair =>
+        {
+            var (list, size) = pair;
+            var expected = list.Chunk(size).Select(chunk => chunk.ToList()).ToList();
+            var actual = await Collect(new ChunkTransformer<int>(size).TransformAsync(ToAsync(list)));
+            Assert.Equal(expected, actual.Select(chunk => chunk.ToList()).ToList());
+        });
+
+    [Fact]
+    public async Task Buffered_preserves_the_sequence() =>
+        await ListAndCapacity().SampleAsync(async pair =>
+        {
+            var (list, capacity) = pair;
+            var actual = await Collect(new BufferedTransformer<int>(capacity).TransformAsync(ToAsync(list)));
+            Assert.Equal(list, actual);
+        });
+
+    [Fact]
+    public async Task PassThrough_is_the_identity() =>
+        await IntLists.SampleAsync(async list =>
+        {
+            var actual = await Collect(new PassThroughTransformer<int>().TransformAsync(ToAsync(list)));
+            Assert.Equal(list, actual);
+        });
+
+    private static Gen<(List<int> List, int Count)> ListAndCount() =>
+        from list in IntLists
+        from n in Gen.Int[0, 60]
+        select (list, n);
+
+    private static Gen<(List<int> List, int Size)> ListAndSize() =>
+        from list in IntLists
+        from size in Gen.Int[1, 10]
+        select (list, size);
+
+    private static Gen<(List<int> List, int Capacity)> ListAndCapacity() =>
+        from list in IntLists
+        from capacity in Gen.Int[1, 10]
+        select (list, capacity);
+
+    private static bool IsEven(int x) => x % 2 == 0;
+
+    private static bool IsNonNegative(int x) => x >= 0;
+
+    private static long Times10(int x) => x * 10L;
+
+    private static int Mod3(int x) => ((x % 3) + 3) % 3;
+
+    private static IEnumerable<int> PlusMinus(int x) => new[] { x, -x };
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(
+        IEnumerable<T> items,
+        [EnumeratorCancellation] CancellationToken token = default)
+    {
+        foreach (var item in items)
+        {
+            token.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+    private static async Task<List<T>> Collect<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items.ConfigureAwait(false))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Property-based ("fuzz") tests: each property asserts a transformer is
+    equivalent to its System.Linq reference over randomized inputs. Runs a small
+    case count per property in the normal test pass (seconds) and a large budget
+    on the scheduled fuzz.yaml workflow (CsCheck honours the CsCheck_Iter /
+    CsCheck_Time environment variables). Single modern TFM — a meta-test, not part
+    of the shipped multi-TFM matrix.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsCheck" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Thorough-review series (base `main`).

## What
- **`tests/…Tests.Fuzz/`** — CsCheck property tests asserting each transformer is **equivalent to its `System.Linq` reference** over randomized inputs: `Where`, `Select`, `SelectMany`, `Distinct`, `DistinctBy`, `Take`, `Skip`, `TakeWhile`, `SkipWhile`, `Chunk`, `Buffered`, `PassThrough`. CsCheck shrinks any counter-example to its minimal form.
- **`.github/workflows/fuzz.yaml`** — weekly + `workflow_dispatch`, `CsCheck_Iter=100000` (100k cases/property), uploads the `.trx` (failing property + reproducible seed) as an artifact, and files a `thorough-review` issue on failure (dedup-guarded).
- Same properties run a **small** case count in the normal PR pass (seconds), so regressions are caught per-PR too.

## Verification
12 properties pass at default and at `CsCheck_Iter=20000` (20k cases each, 4s); clean Release build (0 warnings).

## Merge note
Adds a workflow file → `Detect .NET Projects` guard fails by design → **admin-bypass**.

Closes #76