### PR TITLE
ci: Native-AOT + trim smoke test (closes #90)

### DIFF
--- a/.github/aot/AotConsumer.csproj
+++ b/.github/aot/AotConsumer.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A tiny console consumer that exercises the whole public transformer surface
+    and is published Native-AOT + trimmed. If the library relied on reflection
+    the trimmer can't see, dynamic generic instantiation, or runtime codegen, the
+    AOT publish emits IL2xxx/IL3xxx trim/AOT warnings (the workflow fails on any)
+    or the native binary faults at runtime. ProjectReference (not the package) so
+    the smoke runs against the working tree.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <!-- Surface every trim/AOT warning individually (not collapsed) so the
+         workflow's grep catches them, and treat them as build-breaking. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <TransformersProject Condition="'$(TransformersProject)' == ''">../../src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj</TransformersProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TransformersProject)" />
+  </ItemGroup>
+
+</Project>

--- a/.github/aot/AotConsumer.csproj
+++ b/.github/aot/AotConsumer.csproj
@@ -15,6 +15,12 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <PublishAot>true</PublishAot>
     <PublishTrimmed>true</PublishTrimmed>
+    <!-- The empty Directory.Build.props stub blocks the repo's package-based analyzers, but
+         the SDK's built-in NetAnalyzers (CA*) still run and pick up the repo .editorconfig
+         severities, spamming this throwaway harness with CA2007/CA1849 warnings. Turn them
+         off to complete the isolation. This does NOT affect trim/AOT (IL2xxx/IL3xxx) detection,
+         which comes from the ILC compiler, not the CA analyzers. -->
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <!-- Surface every trim/AOT warning individually (not collapsed) so the
          workflow's grep catches them, and treat them as build-breaking. -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>

--- a/.github/aot/Directory.Build.props
+++ b/.github/aot/Directory.Build.props
@@ -1,0 +1,7 @@
+<!--
+  Isolation stub. MSBuild imports only the nearest Directory.Build.props, so this
+  empty project stops the repo-root one (analyzers, BannedSymbols, multi-TFM,
+  PublicAPI, PackageValidation) from applying to the throwaway AOT smoke consumer.
+-->
+<Project>
+</Project>

--- a/.github/aot/Directory.Build.targets
+++ b/.github/aot/Directory.Build.targets
@@ -1,0 +1,3 @@
+<!-- Isolation stub — see Directory.Build.props in this folder. -->
+<Project>
+</Project>

--- a/.github/aot/Program.cs
+++ b/.github/aot/Program.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Transformers;
+
+// Roots every public method of the library so the trimmer/AOT compiler must
+// analyze the whole reachable graph. A silent no-op is caught by the count
+// assertions; a trim/AOT-incompatible construct fails the publish (IL2xxx/IL3xxx)
+// or faults the native binary at runtime.
+
+var failures = new List<string>();
+
+async Task Check(string name, int expected, IAsyncEnumerable<object?> sequence)
+{
+    var count = 0;
+    await foreach (var _ in sequence.ConfigureAwait(false))
+    {
+        count++;
+    }
+
+    if (count != expected)
+    {
+        failures.Add($"{name}: expected {expected} items, got {count}");
+    }
+    else
+    {
+        Console.WriteLine($"  ok  {name} ({count})");
+    }
+}
+
+static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items, [EnumeratorCancellation] CancellationToken token = default)
+{
+    foreach (var item in items)
+    {
+        token.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return item;
+    }
+}
+
+static IAsyncEnumerable<object?> Box<T>(IAsyncEnumerable<T> source) => Cast(source);
+
+static async IAsyncEnumerable<object?> Cast<T>(IAsyncEnumerable<T> source, [EnumeratorCancellation] CancellationToken token = default)
+{
+    await foreach (var item in source.WithCancellation(token).ConfigureAwait(false))
+    {
+        yield return item;
+    }
+}
+
+var ints = new[] { 1, 2, 3, 4, 5 };
+var withDupes = new[] { 1, 1, 2, 3, 3 };
+var objects = new object[] { "a", 1, "b", 2 };
+
+Console.WriteLine("Transformers:");
+await Check("Where", 2, Box(new WhereTransformer<int>(x => x % 2 == 0).TransformAsync(ToAsync(ints))));
+await Check("Where(async)", 2, Box(new WhereTransformer<int>(x => new ValueTask<bool>(x % 2 == 0)).TransformAsync(ToAsync(ints))));
+await Check("Select", 5, Box(new SelectTransformer<int, string>(x => x.ToString()).TransformAsync(ToAsync(ints))));
+await Check("Select(async)", 5, Box(new SelectTransformer<int, int>(x => new ValueTask<int>(x)).TransformAsync(ToAsync(ints))));
+await Check("SelectMany", 10, Box(new SelectManyTransformer<int, int>(x => new[] { x, -x }).TransformAsync(ToAsync(ints))));
+await Check("SelectMany(async)", 5, Box(new SelectManyTransformer<int, int>(x => ToAsync(new[] { x })).TransformAsync(ToAsync(ints))));
+await Check("Distinct", 3, Box(new DistinctTransformer<int>().TransformAsync(ToAsync(withDupes))));
+await Check("Distinct(comparer)", 3, Box(new DistinctTransformer<int>(EqualityComparer<int>.Default).TransformAsync(ToAsync(withDupes))));
+await Check("DistinctBy", 2, Box(new DistinctByTransformer<int, int>(x => x % 2).TransformAsync(ToAsync(ints))));
+await Check("Take", 2, Box(new TakeTransformer<int>(2).TransformAsync(ToAsync(ints))));
+await Check("Skip", 3, Box(new SkipTransformer<int>(2).TransformAsync(ToAsync(ints))));
+await Check("TakeWhile", 2, Box(new TakeWhileTransformer<int>(x => x < 3).TransformAsync(ToAsync(ints))));
+await Check("TakeWhile(async)", 2, Box(new TakeWhileTransformer<int>(x => new ValueTask<bool>(x < 3)).TransformAsync(ToAsync(ints))));
+await Check("SkipWhile", 3, Box(new SkipWhileTransformer<int>(x => x < 3).TransformAsync(ToAsync(ints))));
+await Check("SkipWhile(async)", 3, Box(new SkipWhileTransformer<int>(x => new ValueTask<bool>(x < 3)).TransformAsync(ToAsync(ints))));
+await Check("Chunk", 3, Box(new ChunkTransformer<int>(2).TransformAsync(ToAsync(ints))));
+await Check("Chunk(progress)", 3, Box(new ChunkTransformer<int>(2, new Progress<int>()).TransformAsync(ToAsync(ints))));
+await Check("Cast", 4, Box(new CastTransformer<object, object>().TransformAsync(ToAsync(objects))));
+await Check("OfType", 2, Box(new OfTypeTransformer<object, string>().TransformAsync(ToAsync(objects))));
+await Check("PassThrough", 5, Box(new PassThroughTransformer<int>().TransformAsync(ToAsync(ints))));
+await Check("PassThrough(ct)", 5, Box(new PassThroughTransformer<int>().TransformAsync(ToAsync(ints), CancellationToken.None)));
+await Check("Buffered", 5, Box(new BufferedTransformer<int>(2).TransformAsync(ToAsync(ints))));
+await Check("ProgressReporting", 5, Box(new ProgressReportingTransformer<int>(_ => { }).TransformAsync(ToAsync(ints))));
+await Check("ProgressReporting(async)", 5, Box(new ProgressReportingTransformer<int>(_ => default).TransformAsync(ToAsync(ints))));
+
+Console.WriteLine("Composition:");
+var chain = new ChainTransformer<int, int, string>(new WhereTransformer<int>(x => x > 1), new SelectTransformer<int, string>(x => x.ToString()));
+await Check("ChainTransformer", 4, Box(chain.TransformAsync(ToAsync(ints))));
+var chainCt = new ChainTransformerWithCancellation<int, int, int>(new PassThroughTransformer<int>(), new PassThroughTransformer<int>());
+await Check("ChainTransformerWithCancellation", 5, Box(chainCt.TransformAsync(ToAsync(ints), CancellationToken.None)));
+var then = new WhereTransformer<int>(x => x > 1).Then(new SelectTransformer<int, string>(x => x.ToString()));
+await Check("Then", 4, Box(then.TransformAsync(ToAsync(ints))));
+var thenCt = new PassThroughTransformer<int>().Then(new PassThroughTransformer<int>());
+await Check("Then(cancellation)", 5, Box(thenCt.TransformAsync(ToAsync(ints), CancellationToken.None)));
+await Check("Buffered(extension)", 5, Box(ToAsync(ints).Buffered(2)));
+
+Console.WriteLine("Pipeline operators:");
+await Check("op Where", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).Where(x => x % 2 == 0).AsAsyncEnumerable()));
+await Check("op Where(async)", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).Where(x => new ValueTask<bool>(x % 2 == 0)).AsAsyncEnumerable()));
+await Check("op Select", 5, Box(EtlPipeline.Create().From(ToAsync(ints)).Select(x => x.ToString()).AsAsyncEnumerable()));
+await Check("op Select(async)", 5, Box(EtlPipeline.Create().From(ToAsync(ints)).Select(x => new ValueTask<int>(x)).AsAsyncEnumerable()));
+await Check("op SelectMany", 10, Box(EtlPipeline.Create().From(ToAsync(ints)).SelectMany(x => new[] { x, -x }).AsAsyncEnumerable()));
+await Check("op SelectMany(async)", 5, Box(EtlPipeline.Create().From(ToAsync(ints)).SelectMany(x => ToAsync(new[] { x })).AsAsyncEnumerable()));
+await Check("op Distinct", 3, Box(EtlPipeline.Create().From(ToAsync(withDupes)).Distinct().AsAsyncEnumerable()));
+await Check("op DistinctBy", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).DistinctBy(x => x % 2).AsAsyncEnumerable()));
+await Check("op Take", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).Take(2).AsAsyncEnumerable()));
+await Check("op Skip", 3, Box(EtlPipeline.Create().From(ToAsync(ints)).Skip(2).AsAsyncEnumerable()));
+await Check("op TakeWhile", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).TakeWhile(x => x < 3).AsAsyncEnumerable()));
+await Check("op TakeWhile(async)", 2, Box(EtlPipeline.Create().From(ToAsync(ints)).TakeWhile(x => new ValueTask<bool>(x < 3)).AsAsyncEnumerable()));
+await Check("op SkipWhile", 3, Box(EtlPipeline.Create().From(ToAsync(ints)).SkipWhile(x => x < 3).AsAsyncEnumerable()));
+await Check("op SkipWhile(async)", 3, Box(EtlPipeline.Create().From(ToAsync(ints)).SkipWhile(x => new ValueTask<bool>(x < 3)).AsAsyncEnumerable()));
+await Check("op Chunk", 3, Box(EtlPipeline.Create().From(ToAsync(ints)).Chunk(2).AsAsyncEnumerable()));
+await Check("op Buffered", 5, Box(EtlPipeline.Create().From(ToAsync(ints)).Buffered(2).AsAsyncEnumerable()));
+await Check("op Cast", 4, Box(EtlPipeline.Create().From(ToAsync(objects)).Cast<object, object>().AsAsyncEnumerable()));
+await Check("op OfType", 2, Box(EtlPipeline.Create().From(ToAsync(objects)).OfType<object, string>().AsAsyncEnumerable()));
+
+if (failures.Count > 0)
+{
+    Console.Error.WriteLine($"AOT smoke FAILED — {failures.Count} mismatch(es):");
+    foreach (var failure in failures)
+    {
+        Console.Error.WriteLine("  " + failure);
+    }
+
+    return 1;
+}
+
+Console.WriteLine("AOT smoke passed — full public surface ran natively.");
+return 0;

--- a/.github/workflows/aot.yaml
+++ b/.github/workflows/aot.yaml
@@ -1,0 +1,72 @@
+name: AOT Smoke
+
+# Publishes a console consumer that roots the whole public surface with
+# Native AOT + trimming. Fails on any IL2xxx/IL3xxx trim/AOT warning (the library
+# must not rely on reflection the trimmer can't see, dynamic generic
+# instantiation, or runtime codegen) and asserts the native binary runs the
+# surface correctly. Runs on PRs so AOT regressions block before merge.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aot-smoke:
+    name: Native-AOT publish + run
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src project
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install AOT prerequisites
+        if: steps.detect.outputs.found == 'true'
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      # IlcTreatWarningsAsErrors already fails the publish on AOT (IL3xxx)
+      # warnings; the grep additionally catches trimmer (IL2xxx) warnings.
+      - name: Publish Native-AOT + trimmed
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          set -o pipefail
+          dotnet publish .github/aot/AotConsumer.csproj -c Release -r linux-x64 2>&1 | tee aot-publish.log
+          if grep -qE ': (warning|error) IL[0-9]' aot-publish.log; then
+            echo "::error::Trim/AOT (ILxxxx) diagnostics found — the library is not AOT/trim-clean. See log."
+            exit 1
+          fi
+
+      - name: Run the native binary
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          binary="$(find .github/aot/bin -type f -name AotConsumer ! -name '*.dll' | head -n1)"
+          if [ -z "$binary" ] || [ ! -x "$binary" ]; then
+            echo "::error::Native AotConsumer binary not found under .github/aot/bin."
+            exit 1
+          fi
+          echo "Running native binary: $binary"
+          "$binary"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
Thorough-review series (base `main`).

## What
- **`.github/aot/`** — a console consumer that **roots the entire public surface** (every transformer, composition helper, and pipeline operator, sync + async overloads — 46 call sites) and is published **`PublishAot` + `PublishTrimmed`**. Count assertions catch silent no-ops. Isolated from repo analyzers via empty `Directory.Build.props`.
- **`.github/workflows/aot.yaml`** (PR + dispatch) — installs the AOT toolchain, publishes for `linux-x64`, **fails on any `IL2xxx`/`IL3xxx` trim/AOT diagnostic** (`IlcTreatWarningsAsErrors` + a grep backstop), then runs the **native binary** and asserts the surface ran. Gates PRs so AOT regressions block before merge.

The transformers use no reflection / dynamic codegen, so they should be AOT/trim-clean — this proves and guards it.

## Verification
Local non-AOT run (Windows can't AOT-publish): **all 46 checks pass**. The AOT publish + native run execute on the Linux CI job.

## Merge note
Adds a workflow → `Detect .NET Projects` guard fails by design → **admin-bypass**.

Closes #90