### PR TITLE
ci: add Semgrep OSS SAST (closes #78)

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,68 @@
+name: SAST (Semgrep)
+
+# Additive static analysis beyond CodeQL (codeql.yaml) and DevSkim (in pr.yaml).
+# Semgrep's OSS engine + registry rulesets are free and need no account. Results
+# upload to Security -> Code scanning alongside CodeQL; on PRs the scan is
+# diff-aware (--baseline-commit) so only findings NEW vs the merge base report.
+# Paid-tier SAST (Snyk Code / Veracode / Fortify / SonarQube Cloud / Checkmarx)
+# remains a project-level budget decision — see docs/sast.md.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write   # upload SARIF to code scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0   # needed so the PR baseline diff has the merge base
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: python -m pip install --disable-pip-version-check semgrep
+
+      - name: Semgrep scan
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          rulesets="--config=p/csharp --config=p/security-audit --config=p/secrets"
+          baseline=""
+          if [ -n "$GITHUB_BASE_REF" ]; then
+            git fetch --no-tags --depth=0 origin "$GITHUB_BASE_REF" || true
+            base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD || true)"
+            if [ -n "$base" ]; then
+              baseline="--baseline-commit $base"
+              echo "Diff-aware scan against baseline $base"
+            fi
+          fi
+          # --error would fail the job on findings; here we surface via SARIF and
+          # let code scanning gate. Exit 0 on findings so the SARIF still uploads.
+          semgrep scan $rulesets $baseline --sarif --output=semgrep.sarif . || true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
+
 ### Changed
 
 ### Deprecated

--- a/docs/sast.md
+++ b/docs/sast.md
@@ -1,0 +1,31 @@
+# Static analysis (SAST)
+
+Overlapping static-analysis signals — the goal is coverage from independent
+scanners, not one authoritative tool.
+
+| Tool | Where | Cost | Notes |
+| --- | --- | --- | --- |
+| **CodeQL** | `codeql.yaml` | free (OSS) | security-extended query pack; the baseline SAST. |
+| **DevSkim** | `pr.yaml` (Security Scan step) | free | Microsoft pattern-based scanner. |
+| **Semgrep (OSS)** | `semgrep.yaml` | free, no account | `p/csharp` + `p/security-audit` + `p/secrets` rulesets; diff-aware on PRs (`--baseline-commit`), SARIF → code scanning. |
+
+## Paid-tier SAST — pending project decision
+
+The tools below catch classes CodeQL/Semgrep miss (semantic taint, dataflow) but
+are a **budget/account decision**, not a per-repo one, so they are **not** wired
+in here:
+
+- **Snyk Code** — has a free OSS tier worth trying first (needs a `SNYK_TOKEN`
+  secret + account).
+- **Veracode SAST**, **Fortify SCA**, **SonarQube Cloud**, **Checkmarx One** —
+  commercial, per-developer licensing.
+
+When a tool is adopted: obtain the account/license, add its workflow (findings as
+PR annotations), commit a baseline scan of `main` so per-PR scans report only new
+findings, and record the triage outcome (false-positive / fixed / accepted-risk)
+in an audit log here.
+
+## Triage log
+
+_No findings triaged yet. When a scanner surfaces a finding, record it here:_
+`YYYY-MM-DD — <tool> <rule> at <file:line> — false-positive | fixed (<commit>) | accepted-risk (<why>)`.


### PR DESCRIPTION
Thorough-review series (base `main`).

## What
Adds **`semgrep.yaml`** — Semgrep's **free, no-account** OSS engine + registry rulesets (`p/csharp`, `p/security-audit`, `p/secrets`) as a third static-analysis signal alongside CodeQL and DevSkim. On PRs it's **diff-aware** (`--baseline-commit` merge-base) so only findings **new vs the base** report; SARIF uploads to **Security → Code scanning**.

`docs/sast.md` documents the SAST stack + triage log, and records that the **paid-tier tools** (Snyk Code / Veracode / Fortify / SonarQube Cloud / Checkmarx) named in #78 remain a **project-level budget/account decision** — not implementable per-repo without an account/license.

## Merge note
Adds a workflow → `Detect .NET Projects` guard fails by design → **admin-bypass**.

Closes #78