### PR TITLE
test: Verify snapshot tests for structured output (closes #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
+
 ### Changed
 
 ### Deprecated

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -47,6 +47,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj" />
+    <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj" />
   </Folder>
 </Solution>

--- a/docs/snapshot-testing.md
+++ b/docs/snapshot-testing.md
@@ -1,0 +1,31 @@
+# Snapshot (approval) testing
+
+`tests/Wolfgang.Etl.Transformers.Tests.Snapshots` uses
+[Verify](https://github.com/VerifyTests/Verify) to lock the **shape** of
+representative complex output so accidental format/behaviour drift is caught by a
+diff against a committed `.verified.txt`.
+
+## Scope (intentionally narrow)
+
+The library is largely a **pure-data pass-through**: the transformers filter,
+project, dedup, and batch generic `T` streams and render **no** text, JSON, XML,
+or CSV. So snapshot testing has limited applicability — it is valuable only where
+the *composed* output has an interesting shape. The committed snapshots cover:
+
+- a **record/anonymous-object projection** (`Select`),
+- a **chunk grouping** (`Chunk` — nested list structure), and
+- an **end-to-end pipeline** (`DistinctBy` → `Select`).
+
+Targeted unit tests remain the primary coverage; these snapshots are a
+drift-detector on the structured shapes above.
+
+## Working with snapshots
+
+- Snapshots live next to the test under `Snapshots/` as `*.verified.txt` and are
+  committed.
+- On a change, the run writes `*.received.txt` and fails; review the diff and, if
+  the new output is correct, replace the `.verified.txt` with it (or use your
+  Verify diff tool). `*.received.*` is gitignored.
+- CI just diffs against the committed `.verified.txt`. `DeterministicSourcePaths`
+  is disabled for this project so Verify resolves the files by their real path on
+  the runner.

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/.gitignore
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/.gitignore
@@ -1,0 +1,2 @@
+# Verify received snapshots are transient local iteration output.
+*.received.*

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Chunk_grouping_shape.verified.txt
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Chunk_grouping_shape.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  [
+    {
+      Id: 1,
+      Name: Ada,
+      City: London
+    },
+    {
+      Id: 2,
+      Name: Alan,
+      City: London
+    }
+  ],
+  [
+    {
+      Id: 3,
+      Name: Grace,
+      City: New York
+    },
+    {
+      Id: 4,
+      Name: Edsger,
+      City: Rotterdam
+    }
+  ],
+  [
+    {
+      Id: 5,
+      Name: Barbara,
+      City: New York
+    }
+  ]
+]

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Pipeline_filter_dedup_project.verified.txt
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Pipeline_filter_dedup_project.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    City: London,
+    Representative: Ada
+  },
+  {
+    City: New York,
+    Representative: Grace
+  },
+  {
+    City: Rotterdam,
+    Representative: Edsger
+  }
+]

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Select_projection_to_records.verified.txt
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.Select_projection_to_records.verified.txt
@@ -1,0 +1,22 @@
+﻿[
+  {
+    Id: 1,
+    Upper: ADA
+  },
+  {
+    Id: 2,
+    Upper: ALAN
+  },
+  {
+    Id: 3,
+    Upper: GRACE
+  },
+  {
+    Id: 4,
+    Upper: EDSGER
+  },
+  {
+    Id: 5,
+    Upper: BARBARA
+  }
+]

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Snapshots/TransformerSnapshotTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static VerifyXunit.Verifier;
+
+namespace Wolfgang.Etl.Transformers.Tests.Snapshots;
+
+/// <summary>
+/// Snapshot (approval) tests over representative complex-shaped transformer
+/// output. The library is mostly a pure-data pass-through (no text/JSON/XML/CSV
+/// rendering), so snapshot coverage is intentionally narrow — see
+/// <c>docs/snapshot-testing.md</c>. These lock the shape of a record projection,
+/// a chunk grouping, and an end-to-end pipeline so accidental drift is caught by
+/// a diff against the committed <c>.verified.txt</c>.
+/// </summary>
+public class TransformerSnapshotTests
+{
+    private sealed record Person(int Id, string Name, string City);
+
+    private static readonly Person[] People =
+    {
+        new(1, "Ada", "London"),
+        new(2, "Alan", "London"),
+        new(3, "Grace", "New York"),
+        new(4, "Edsger", "Rotterdam"),
+        new(5, "Barbara", "New York"),
+    };
+
+    [Fact]
+    public async Task Select_projection_to_records()
+    {
+        var result = await Collect
+        (
+            new SelectTransformer<Person, object>(p => new { p.Id, Upper = p.Name.ToUpperInvariant() })
+                .TransformAsync(ToAsync(People))
+        );
+
+        await Verify(result);
+    }
+
+    [Fact]
+    public async Task Chunk_grouping_shape()
+    {
+        var result = await Collect(new ChunkTransformer<Person>(2).TransformAsync(ToAsync(People)));
+
+        await Verify(result);
+    }
+
+    [Fact]
+    public async Task Pipeline_filter_dedup_project()
+    {
+        var byCity = new DistinctByTransformer<Person, string>(p => p.City);
+        var project = new SelectTransformer<Person, object>(p => new { p.City, Representative = p.Name });
+
+        var result = await Collect(project.TransformAsync(byCity.TransformAsync(ToAsync(People))));
+
+        await Verify(result);
+    }
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(
+        IEnumerable<T> items,
+        [EnumeratorCancellation] CancellationToken token = default)
+    {
+        foreach (var item in items)
+        {
+            token.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+    private static async Task<List<T>> Collect<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items.ConfigureAwait(false))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Snapshot (approval) tests via Verify. Captures the shape of representative
+    complex/structured transformer output so accidental format/behaviour drift is
+    caught by a diff against the committed .verified.txt. Single modern TFM —
+    Verify does not support the down-level .NET Framework targets, and this is a
+    meta-test not part of the shipped matrix.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- Keep real source paths so Verify resolves .verified files in CI too. -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Verify.Xunit" Version="31.12.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Thorough-review series (base `main`).

## What
Adds `tests/…Tests.Snapshots` (net10.0) using **Verify**. Snapshots lock the shape of the library's few complex-shaped outputs — a record/anonymous-object projection, a `Chunk` nested grouping, and a `DistinctBy`→`Select` pipeline. The transformers otherwise render no text/JSON/XML/CSV, so coverage is **intentionally narrow** (per the issue's "pure-data library" note) — documented in `docs/snapshot-testing.md`.

`.verified.txt` committed under `Snapshots/`; `.received.*` gitignored; `DeterministicSourcePaths=false` so Verify resolves the files on the CI runner.

## Verification
3 snapshots generated + accepted; re-run passes (3/3).

Closes #87