### PR TITLE
test: enforce zero-allocation hot path (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
 ### Changed
 
 ### Deprecated

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -45,6 +45,7 @@
     <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj" />

--- a/docs/allocation-budget.md
+++ b/docs/allocation-budget.md
@@ -1,0 +1,54 @@
+# Allocation budget
+
+Some public call sites are deliberately allocation-free. This document lists them,
+explains what is *not* covered and why, and describes how the guarantee is enforced.
+
+## Enforced zero-allocation hot paths
+
+| Call site | Guarantee | Enforced by |
+| --- | --- | --- |
+| `PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` (single-argument overload) | Returns the source sequence **unchanged and by reference**, allocating **0 bytes** — no wrapping iterator. | `AllocationBudgetTests.PassThroughTransformer_single_arg_TransformAsync_allocates_zero_bytes` (asserts a byte delta of exactly `0`) and `..._returns_same_instance` (asserts reference identity). |
+
+This is the library's one intentional zero-allocation hot path. Because it performs
+no work, `PassThroughTransformer<T>` implements `ITransformWithCancellationAsync<T, T>`
+directly rather than deriving from `TransformerBase<,,>`, and its single-argument
+overload short-circuits to `return items;`.
+
+## Deliberately out of scope
+
+Every other transformer in this package is a **streaming** transformer: it wraps the
+source in a C# async iterator (`async IAsyncEnumerable<T>`) so that items flow lazily
+with cancellation support. Constructing that iterator allocates exactly one state-machine
+object **per enumeration** — this is inherent to `IAsyncEnumerable<T>` and is not a
+regression to be eliminated. The cancellation-aware
+`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>, CancellationToken)`
+overload is the clearest example, and
+`AllocationBudgetTests.PassThroughTransformer_cancellation_overload_allocates` asserts
+it *does* allocate — locking in the documented distinction between the two overloads.
+
+Per-**item** steady-state allocation is intentionally not asserted here: for streaming
+transformers it depends on the caller-supplied `selector` / `predicate` delegates and on
+the source sequence's own `MoveNextAsync` completion behaviour, neither of which the
+transformer controls. Measuring it would test the caller's code, not this library's.
+
+## Measurement methodology
+
+The tests use `GC.GetAllocatedBytesForCurrentThread()`, a per-thread cumulative counter:
+
+- **Same-thread measurement.** Each measured section is fully synchronous (no `await`),
+  so the before/after reads happen on the same thread. An `await` that resumes on a
+  different thread would read a *different* thread's counter and produce a meaningless
+  delta — this is the standard async caveat for this API.
+- **Warm-up.** A warm-up loop runs first so JIT/tiered-compilation allocations are not
+  counted against the measured window.
+- **No collection needed.** The counter is cumulative and unaffected by garbage
+  collections, so no `GC.Collect()` dance is required.
+
+## Regression behaviour
+
+If a change makes the zero-alloc overload allocate, the assertion fails with the actual
+byte delta and the offending test name, pointing straight at the regressed call site.
+
+The tests live in `tests/Wolfgang.Etl.Transformers.Tests.Allocation` and target `net10.0`
+only: the contract is a runtime property, and pinning one modern runtime keeps the
+allocation numbers stable and deterministic.

--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/AllocationBudgetTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/AllocationBudgetTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Transformers;
+using Xunit;
+
+namespace Wolfgang.Etl.Transformers.Tests.Allocation;
+
+/// <summary>
+/// Verifies the library's documented zero-allocation hot paths stay allocation-free.
+/// See <c>docs/allocation-budget.md</c> for the full list and the rationale for what
+/// is (and deliberately is not) covered here.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Measurement uses <see cref="GC.GetAllocatedBytesForCurrentThread"/>, a per-thread
+/// cumulative counter. Each measured section is fully synchronous (no <c>await</c>) so
+/// the before/after reads happen on the same thread and the delta is exact — an
+/// <c>await</c> that resumes on a different thread would read a different thread's counter.
+/// A warm-up loop first forces JIT compilation so tiered-compilation allocations do not
+/// leak into the measured window.
+/// </para>
+/// </remarks>
+public sealed class AllocationBudgetTests
+{
+    private const int WarmupIterations = 200;
+
+    private const int MeasuredIterations = 1000;
+
+
+    // A synchronous-completing async sequence. Constructed once, outside every measured
+    // window, so building the iterator is never counted against the hot path under test.
+    private static async IAsyncEnumerable<int> RangeAsync(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+
+    /// <summary>
+    /// The single-argument <see cref="PassThroughTransformer{T}.TransformAsync(IAsyncEnumerable{T})"/>
+    /// overload is documented to return the source sequence directly, without allocating a
+    /// wrapping iterator. This is the one intentional zero-allocation hot path in the library.
+    /// </summary>
+    [Fact]
+    public void PassThroughTransformer_single_arg_TransformAsync_allocates_zero_bytes()
+    {
+        var transformer = new PassThroughTransformer<int>();
+        var source = RangeAsync(4);
+
+        // Warm up: JIT the call, resolve the interface dispatch, tier up.
+        for (var i = 0; i < WarmupIterations; i++)
+        {
+            _ = transformer.TransformAsync(source);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        for (var i = 0; i < MeasuredIterations; i++)
+        {
+            _ = transformer.TransformAsync(source);
+        }
+
+        var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal
+        (
+            0,
+            delta
+        );
+    }
+
+
+    /// <summary>
+    /// The identity return is what makes the single-argument overload allocation-free:
+    /// it hands back the very same sequence instance it was given.
+    /// </summary>
+    [Fact]
+    public void PassThroughTransformer_single_arg_TransformAsync_returns_same_instance()
+    {
+        var transformer = new PassThroughTransformer<int>();
+        var source = RangeAsync(4);
+
+        var result = transformer.TransformAsync(source);
+
+        Assert.Same
+        (
+            source,
+            result
+        );
+    }
+
+
+    /// <summary>
+    /// Contrast case: the cancellation-aware overload wraps the source in a streaming
+    /// iterator, so it necessarily allocates. This locks in the documented distinction
+    /// between the two overloads — a regression that made the single-arg overload wrap
+    /// would be caught by the zero-alloc test above; this guards the reverse assumption.
+    /// </summary>
+    [Fact]
+    public void PassThroughTransformer_cancellation_overload_allocates()
+    {
+        var transformer = new PassThroughTransformer<int>();
+        var source = RangeAsync(4);
+
+        for (var i = 0; i < WarmupIterations; i++)
+        {
+            _ = transformer.TransformAsync(source, CancellationToken.None);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        for (var i = 0; i < MeasuredIterations; i++)
+        {
+            _ = transformer.TransformAsync(source, CancellationToken.None);
+        }
+
+        var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True
+        (
+            delta > 0,
+            $"Expected the streaming overload to allocate a wrapping iterator, but it allocated {delta} bytes."
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Allocation-budget tests. net10.0 only: GC.GetAllocatedBytesForCurrentThread is a
+    per-thread cumulative counter whose behaviour is stable on modern .NET, and the
+    zero-alloc contract under test is a runtime property, not a per-TFM API surface.
+    See docs/allocation-budget.md for the documented list of hot paths and the rationale.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Implements #94 — allocation-free hot-path verification.

## What

A new **`tests/Wolfgang.Etl.Transformers.Tests.Allocation`** project (net10.0) that asserts the library's zero-allocation contract via `GC.GetAllocatedBytesForCurrentThread()`:

- `PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` (single-arg) — the one intentional zero-alloc hot path — returns the source **by reference**, allocating **0 bytes**. Two tests: byte-delta `== 0` over a warmed, fully-synchronous window, and reference identity (`Assert.Same`).
- Contrast test: the cancellation-aware overload **does** allocate (it wraps in a streaming iterator), locking in the documented distinction so a regression either direction is caught.

**`docs/allocation-budget.md`** documents the covered call sites, why every other (streaming) transformer is deliberately out of scope, and the measurement methodology (same-thread sync window, warm-up, per-thread cumulative counter — the async caveat the issue calls out).

## Verification

```
Passed! - Failed: 0, Passed: 3, Skipped: 0, Total: 3 (net10.0)
```

Measurement is intentionally net10.0-only: the contract is a runtime property, and pinning one modern runtime keeps allocation numbers stable/deterministic (mirrors the Fuzz/Snapshots meta-test projects).

Closes #94
