### PR TITLE
ci: gate PRs on BenchmarkDotNet delta vs base (#101)

### DIFF
--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -1,0 +1,157 @@
+name: PR Benchmarks
+
+# Forward-looking perf gate: runs BenchmarkDotNet on the PR head AND on the PR's
+# base commit, computes the per-benchmark time/allocation delta, and posts (or
+# replaces) a sticky comment with the delta table. Fails the PR when a benchmark
+# regresses past the threshold unless the PR carries the `perf-impact-acknowledged`
+# label.
+#
+# Complements benchmarks.yaml (which graphs the post-merge trend on main); this one
+# catches a regression before it merges.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # One run per PR; a new push cancels the in-flight comparison so the sticky
+  # comment always reflects the latest head.
+  group: pr-benchmarks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  BENCH_PROJECT: benchmarks/Wolfgang.Etl.Transformers.Benchmarks/Wolfgang.Etl.Transformers.Benchmarks.csproj
+  BENCH_DIR: benchmarks/Wolfgang.Etl.Transformers.Benchmarks
+  TIME_THRESHOLD: '20'
+  ALLOC_THRESHOLD: '50'
+  ACK_LABEL: perf-impact-acknowledged
+
+jobs:
+  benchmark:
+    name: Compare BDN delta vs base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Full history so the base commit can be checked out into a worktree.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Check benchmark project exists on both sides
+        id: guard
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          head_ok=false
+          base_ok=false
+          [ -f "$BENCH_PROJECT" ] && head_ok=true
+          if git cat-file -e "${BASE_SHA}:${BENCH_PROJECT}" 2>/dev/null; then
+            base_ok=true
+          fi
+          echo "head_ok=$head_ok" >> "$GITHUB_OUTPUT"
+          echo "base_ok=$base_ok" >> "$GITHUB_OUTPUT"
+          if [ "$head_ok" = true ] && [ "$base_ok" = true ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Benchmark project missing on head ($head_ok) or base ($base_ok); skipping perf gate."
+          fi
+
+      - name: Run benchmarks on PR head
+        if: steps.guard.outputs.run == 'true'
+        working-directory: ${{ env.BENCH_DIR }}
+        # ShortRun keeps wall-clock reasonable; --memory adds the allocation column.
+        run: dotnet run -c Release -- --filter "*" --job short --memory --exporters json
+
+      - name: Stash head results
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/head-results"
+          cp -r "$BENCH_DIR/BenchmarkDotNet.Artifacts/results/." "$RUNNER_TEMP/head-results/"
+
+      - name: Run benchmarks on base
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Build the base commit in an isolated worktree so head build outputs and
+          # BDN artifacts don't clash.
+          git worktree add --detach "$RUNNER_TEMP/base" "$BASE_SHA"
+          ( cd "$RUNNER_TEMP/base/$BENCH_DIR" \
+            && dotnet run -c Release -- --filter "*" --job short --memory --exporters json )
+          mkdir -p "$RUNNER_TEMP/base-results"
+          cp -r "$RUNNER_TEMP/base/$BENCH_DIR/BenchmarkDotNet.Artifacts/results/." "$RUNNER_TEMP/base-results/"
+
+      - name: Compute delta
+        id: delta
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/compare-benchmarks.py \
+            --base-dir "$RUNNER_TEMP/base-results" \
+            --head-dir "$RUNNER_TEMP/head-results" \
+            --time-threshold "$TIME_THRESHOLD" \
+            --alloc-threshold "$ALLOC_THRESHOLD" \
+            --out "$RUNNER_TEMP/comment.md" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- pr-benchmarks -->'
+          { printf '%s\n\n' "$marker"; cat "$RUNNER_TEMP/comment.md"; } > "$RUNNER_TEMP/body.md"
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\")) | .id] | first // empty")
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@"$RUNNER_TEMP/body.md" >/dev/null
+            echo "Updated comment $existing"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@"$RUNNER_TEMP/body.md" >/dev/null
+            echo "Created new comment"
+          fi
+
+      - name: Enforce threshold
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.delta.outputs.regressed }}" != "true" ]; then
+            echo "✅ No benchmark regression beyond threshold."
+            exit 0
+          fi
+          acknowledged=$(gh api "repos/$REPO/issues/$PR/labels" \
+            --jq "any(.[]; .name == \"$ACK_LABEL\")")
+          if [ "$acknowledged" = "true" ]; then
+            echo "::warning::Perf regression detected but acknowledged via '$ACK_LABEL' label."
+            exit 0
+          fi
+          echo "::error::Benchmark regression exceeds the threshold (time > ${TIME_THRESHOLD}% or alloc > ${ALLOC_THRESHOLD}%). Review the delta comment, or add the '$ACK_LABEL' label if the change is intentional."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
-  on the PR head and its base commit, posts a sticky delta-table comment, and fails
-  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
-  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
-  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
 - Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
   library's one intentional zero-allocation hot path
   (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
   source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
   `docs/allocation-budget.md` documenting the covered call sites and why streaming
   transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
 ### Changed
 
 ### Deprecated

--- a/docs/pr-benchmarks.md
+++ b/docs/pr-benchmarks.md
@@ -1,0 +1,55 @@
+# Per-PR benchmark regression gate
+
+`.github/workflows/pr-benchmarks.yaml` is the **forward-looking** perf signal: it
+compares a pull request's benchmarks against its own base commit and blocks a merge
+that regresses a hot path. It complements
+[`benchmarks.yaml`](../.github/workflows/benchmarks.yaml), which graphs the
+*backward-looking* trend on `main` after a merge.
+
+## What it does
+
+1. Triggers only when a PR changes `src/**` or `benchmarks/**`.
+2. Runs the BenchmarkDotNet suite (`--job short --memory`) twice: on the PR head, and
+   on the PR's base commit (checked out into an isolated `git worktree`).
+3. Runs [`scripts/compare-benchmarks.py`](../scripts/compare-benchmarks.py), which joins
+   the two runs by benchmark `FullName` and computes the per-benchmark time and
+   allocation delta.
+4. Posts a **sticky** comment (replaced, not appended, on every push) with a delta table.
+5. **Fails the PR** if any benchmark exceeds the threshold — unless the PR carries the
+   `perf-impact-acknowledged` label.
+
+## Thresholds
+
+| Metric | Default fail threshold | Set in |
+| --- | --- | --- |
+| Mean time | more than **20%** slower | `TIME_THRESHOLD` env in the workflow |
+| Allocated bytes | more than **50%** greater (or newly allocating from zero) | `ALLOC_THRESHOLD` env in the workflow |
+
+Time on GitHub-hosted runners is noisy, so a double-digit time delta can be measurement
+jitter rather than a real regression. **Allocation deltas are deterministic** and are the
+reliable signal — a bump there almost always means a real change on the hot path.
+
+Only benchmarks present in *both* runs are gated. Benchmarks added or removed by the PR are
+listed in the comment but never trip the gate.
+
+## Overriding an intentional regression
+
+Some changes trade throughput or allocations for correctness or a new feature. When that
+trade is deliberate, add the **`perf-impact-acknowledged`** label to the PR. The gate then
+reports the regression as a warning instead of failing. Run
+[`scripts/Setup-Labels.ps1`](../scripts/Setup-Labels.ps1) once per repo to create the label.
+
+## Local dry run
+
+You can reproduce the comparison locally against any two BenchmarkDotNet result
+directories (each containing the `*-report-full-compressed.json` files a run emits):
+
+```bash
+python scripts/compare-benchmarks.py \
+  --base-dir path/to/base/BenchmarkDotNet.Artifacts/results \
+  --head-dir path/to/head/BenchmarkDotNet.Artifacts/results \
+  --time-threshold 20 --alloc-threshold 50 \
+  --out delta.md
+```
+
+The script is pure standard-library Python 3 — no jq or other dependency required.

--- a/scripts/Setup-Labels.ps1
+++ b/scripts/Setup-Labels.ps1
@@ -18,6 +18,7 @@
     - maintenance - docs       (blue)   — category: XML docs, README, CHANGELOG, samples
     - maintenance - API        (orange) — category: public/internal surface audit
     - maintenance - CI/CD      (pink)   — category: Docker, CI workflow, build/publish pipeline
+    - perf-impact-acknowledged (gold)   — overrides the PR Benchmarks perf gate for an intentional regression
 
 .PARAMETER Repository
     The repository in owner/repo format. If not provided, uses the current repository.
@@ -100,7 +101,10 @@ $labels = @(
     @{ name = "maintenance - cleanup";     color = "a2845e"; description = "Maintenance: refactor for reuse, quality, efficiency" },
     @{ name = "maintenance - docs";        color = "0075ca"; description = "Maintenance: XML doc coverage, README, CHANGELOG, samples" },
     @{ name = "maintenance - API";         color = "ed7d31"; description = "Maintenance: public/internal surface audit, breaking-change vigilance" },
-    @{ name = "maintenance - CI/CD";       color = "ec6cb9"; description = "Maintenance: Docker, CI workflow, build/publish pipeline" }
+    @{ name = "maintenance - CI/CD";       color = "ec6cb9"; description = "Maintenance: Docker, CI workflow, build/publish pipeline" },
+
+    # PR-benchmarks perf gate — apply to a PR to accept an intentional benchmark regression
+    @{ name = "perf-impact-acknowledged"; color = "fbca04"; description = "Intentional benchmark regression; overrides the PR Benchmarks perf gate" }
 )
 
 $created = 0

--- a/scripts/compare-benchmarks.py
+++ b/scripts/compare-benchmarks.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Compare two BenchmarkDotNet runs (PR base vs head) and emit a delta table.
+
+Reads the ``*-report-full-compressed.json`` files BenchmarkDotNet writes under each
+run's ``BenchmarkDotNet.Artifacts/results`` directory, joins benchmarks by their
+``FullName``, and produces:
+
+* a markdown comment body (``--out``) with a per-benchmark time/allocation delta table,
+* ``regressed=true|false`` on stdout for ``$GITHUB_OUTPUT``.
+
+A benchmark is a regression when its mean time grows by more than ``--time-threshold``
+percent OR its allocated bytes grow by more than ``--alloc-threshold`` percent. Only
+benchmarks present in BOTH runs are gated; added/removed benchmarks are listed but never
+trip the gate.
+
+Used by ``.github/workflows/pr-benchmarks.yaml``. Pure standard library so it runs on any
+runner with Python 3 and needs no jq.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+# A benchmark that newly allocates from a zero baseline has no finite percentage; use a
+# large sentinel so it always exceeds any sane allocation threshold and renders as "new".
+NEW_ALLOC_SENTINEL = 1_000_000_000.0
+
+
+def collect(results_dir: str) -> dict[str, dict[str, float]]:
+    """Map FullName -> {mean, alloc} across every BDN report under results_dir."""
+    out: dict[str, dict[str, float]] = {}
+    pattern = os.path.join(results_dir, "**", "*-report-full-compressed.json")
+    for path in sorted(glob.glob(pattern, recursive=True)):
+        with open(path, encoding="utf-8-sig") as handle:
+            doc = json.load(handle)
+        for bench in doc.get("Benchmarks", []):
+            name = bench.get("FullName")
+            if not name:
+                continue
+            stats = bench.get("Statistics") or {}
+            memory = bench.get("Memory") or {}
+            out[name] = {
+                "mean": float(stats.get("Mean", 0.0)),
+                "alloc": float(memory.get("BytesAllocatedPerOperation", 0) or 0),
+            }
+    return out
+
+
+def pct(base: float, head: float, is_alloc: bool) -> float:
+    if base > 0:
+        return (head - base) / base * 100.0
+    if is_alloc and head > 0:
+        return NEW_ALLOC_SENTINEL
+    return 0.0
+
+
+def fmt_pct(value: float) -> str:
+    if value >= NEW_ALLOC_SENTINEL:
+        return "new"
+    sign = "+" if value > 0 else ""
+    return f"{sign}{round(value, 1)}%"
+
+
+def fmt_ns(value: float) -> str:
+    return f"{round(value, 2)} ns"
+
+
+def fmt_bytes(value: float) -> str:
+    return f"{int(value)} B"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-dir", required=True, help="results dir for the base run")
+    parser.add_argument("--head-dir", required=True, help="results dir for the PR-head run")
+    parser.add_argument("--time-threshold", type=float, required=True, help="max % slower")
+    parser.add_argument("--alloc-threshold", type=float, required=True, help="max % more allocations")
+    parser.add_argument("--out", required=True, help="markdown comment body output path")
+    args = parser.parse_args()
+
+    base = collect(args.base_dir)
+    head = collect(args.head_dir)
+
+    common = sorted(set(base) & set(head))
+    added = sorted(set(head) - set(base))
+    removed = sorted(set(base) - set(head))
+
+    rows = []
+    for name in common:
+        b, h = base[name], head[name]
+        rows.append(
+            {
+                "key": name,
+                "b_mean": b["mean"],
+                "h_mean": h["mean"],
+                "b_alloc": b["alloc"],
+                "h_alloc": h["alloc"],
+                "t_pct": pct(b["mean"], h["mean"], is_alloc=False),
+                "a_pct": pct(b["alloc"], h["alloc"], is_alloc=True),
+            }
+        )
+
+    def is_regression(row: dict) -> bool:
+        return row["t_pct"] > args.time_threshold or row["a_pct"] > args.alloc_threshold
+
+    regressions = [r for r in rows if is_regression(r)]
+
+    lines = [
+        "### 📊 Benchmark delta — PR vs base",
+        "",
+        (
+            f"Threshold: fail if **time > {args.time_threshold:g}%** slower or "
+            f"**allocations > {args.alloc_threshold:g}%** greater (per benchmark). "
+            "Time on hosted runners is noisy; allocation deltas are the reliable signal."
+        ),
+        "",
+    ]
+
+    if not rows:
+        lines.append("_No benchmarks are present in both base and head; nothing to compare._")
+    else:
+        lines.append("| Benchmark | Time (base → head) | Δ time | Alloc (base → head) | Δ alloc |")
+        lines.append("|---|---|---|---|---|")
+        # Worst offenders first: allocation regressions dominate, then time.
+        for row in sorted(rows, key=lambda r: (-min(r["a_pct"], NEW_ALLOC_SENTINEL), -r["t_pct"])):
+            flag = "⚠️ " if is_regression(row) else ""
+            lines.append(
+                f"| {flag}`{row['key']}` "
+                f"| {fmt_ns(row['b_mean'])} → {fmt_ns(row['h_mean'])} | {fmt_pct(row['t_pct'])} "
+                f"| {fmt_bytes(row['b_alloc'])} → {fmt_bytes(row['h_alloc'])} | {fmt_pct(row['a_pct'])} |"
+            )
+
+    if added:
+        lines += ["", "**New benchmarks (not gated):** " + ", ".join(f"`{a}`" for a in added)]
+    if removed:
+        lines += ["", "**Removed benchmarks:** " + ", ".join(f"`{r}`" for r in removed)]
+
+    lines.append("")
+    if regressions:
+        lines.append(
+            f"⚠️ **{len(regressions)} benchmark(s) exceed the threshold.** "
+            "Investigate, or add the `perf-impact-acknowledged` label if the change is intentional."
+        )
+    else:
+        lines.append("✅ No benchmark exceeds the threshold.")
+
+    with open(args.out, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+    print(f"regressed={'true' if regressions else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements #101 — forward-looking per-PR perf regression gate.

## What

- **`.github/workflows/pr-benchmarks.yaml`** — on PRs that touch `src/**` or `benchmarks/**`, runs BenchmarkDotNet (`--job short --memory`) on the **PR head** and on the **base commit** (checked out into an isolated `git worktree`), computes the per-benchmark time/allocation delta, and posts a **sticky** comment (replaced, not appended, on every push). **Fails the PR** when a benchmark is >20% slower or allocates >50% more — unless the PR carries the `perf-impact-acknowledged` label.
- **`scripts/compare-benchmarks.py`** — pure-stdlib Python 3 (no jq): joins the two BDN runs by `FullName`, formats the markdown delta table, marks offenders with ⚠️, lists added/removed benchmarks separately (never gated), and prints `regressed=true|false`.
- **`scripts/Setup-Labels.ps1`** — adds the `perf-impact-acknowledged` override label.
- **`docs/pr-benchmarks.md`** — thresholds, override flow, local dry-run.

## AC mapping

| AC | Where |
|---|---|
| Runs BDN on head and base, computes per-benchmark time/alloc delta | run steps + `compare-benchmarks.py` |
| Comments a markdown delta table | sticky comment step |
| Comment replaced (not appended) each push | marker-based find-then-PATCH via `gh api` + `concurrency: cancel-in-progress` |
| Fails past threshold unless acknowledged | `Enforce threshold` step gated on the `perf-impact-acknowledged` label |
| Runs only when src/ or benchmarks/ change | `on.pull_request.paths` |

## Testing

`compare-benchmarks.py` was exercised locally against synthetic BDN reports covering no-change, time regression, alloc regression, new-from-zero allocation, and added/removed benchmarks — table rendering and the `regressed` flag verified in both directions. Note the workflow itself only triggers on `src/`/`benchmarks/` changes (per AC), so it will first execute end-to-end on the next PR that touches those paths.

Time on hosted runners is noisy; the doc and comment call out that **allocation deltas are the reliable signal**.

Closes #101
