### PR TITLE
docs: consumer-side reproducible-build verification (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
-  how a third party regenerates and diffs the per-release
-  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
-  files a discrepancy, and publishes an independent verification attestation; a "Verify
-  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
-- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
-  library's one intentional zero-allocation hot path
-  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
-  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
-  `docs/allocation-budget.md` documenting the covered call sites and why streaming
-  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
 - Reproducible-build verification: a `Reproducible Build` workflow packs the
   project on Ubuntu and Windows and compares output hashes — same-OS/SDK
   determinism is the guarantee; cross-OS divergence is reported as an advisory
   warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
   documenting the guarantee and how a third party can verify a published package
   against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
+- Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
+  library's one intentional zero-allocation hot path
+  (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
+  source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
+  `docs/allocation-budget.md` documenting the covered call sites and why streaming
+  transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 - Reproducible-build verification: a `Reproducible Build` workflow packs the
   project on Ubuntu and Windows and fails on any byte divergence between the two,
   plus `REPRODUCIBLE-BUILD.md` documenting the guarantee and how a third party can

--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ Documentation is automatically built and deployed to GitHub Pages when a GitHub 
 
 ---
 
+## Verify the build
+
+This package is built [**reproducibly**](REPRODUCIBLE-BUILD.md): rebuilding a tagged
+release with the pinned SDK produces byte-for-byte identical assemblies and packages.
+Every release attaches a `reproducible-build-manifest.json` with the expected SHA-256 of
+each artifact, and CI proves cross-OS reproducibility on every pull request.
+
+To confirm a published release was built from source — and to publish your own
+independent verification attestation — follow the step-by-step guide in
+[REPRODUCIBLE-BUILD.md](REPRODUCIBLE-BUILD.md).
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for code quality standards, build instructions, and pull request guidelines.

--- a/REPRODUCIBLE-BUILD.md
+++ b/REPRODUCIBLE-BUILD.md
@@ -77,3 +77,67 @@ framework.
 > SDK. A different SDK/compiler version can legitimately emit different (but still
 > deterministic) bytes. Use the SDK pinned by the CI workflow (`10.0.x`) when
 > reproducing a release.
+
+## The release manifest
+
+Every published release attaches a **`reproducible-build-manifest.json`** asset (built
+by [`scripts/generate-repro-manifest.py`](scripts/generate-repro-manifest.py) inside
+`release.yaml`). It records, for that exact tag:
+
+- the `repository`, `tag`, `commit`, and `sdkVersion` used,
+- the exact `buildCommand`,
+- the SHA-256 of every published `.nupkg` / `.snupkg`,
+- the SHA-256 of each assembly (`lib/**/*.dll`, `lib/**/*.pdb`) *inside* those packages.
+
+This is the authoritative list of expected hashes — you don't have to eyeball
+individual `sha256sum` output. To verify a release end to end:
+
+```bash
+# 1. Check out the tagged source and pack it with the pinned SDK (see the note above).
+git checkout v<version>
+CI=true dotnet pack src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj \
+  -c Release -p:ContinuousIntegrationBuild=true -p:Deterministic=true -o artifacts
+
+# 2. Regenerate the manifest from your own build.
+python3 scripts/generate-repro-manifest.py --packages artifacts --out my-manifest.json \
+  --repository Chris-Wolfgang/ETL-Transformers --tag v<version>
+
+# 3. Download the published manifest from the GitHub Release and diff the hashes.
+#    (repository/commit/tag/sdk metadata may differ; the `artifacts` hashes must match.)
+curl -sSL -o released-manifest.json \
+  https://github.com/Chris-Wolfgang/ETL-Transformers/releases/download/v<version>/reproducible-build-manifest.json
+diff \
+  <(jq -S '.artifacts' released-manifest.json) \
+  <(jq -S '.artifacts' my-manifest.json)
+```
+
+An empty `diff` is proof that the packages you can rebuild from source are byte-identical
+to the ones that were published.
+
+## File a discrepancy
+
+If any hash differs and you are using the SDK version recorded in the manifest, that is a
+supply-chain signal worth reporting. Please
+[open an issue](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/new) titled
+`Reproducible-build discrepancy: v<version>` and include:
+
+- the release tag and the `sdkVersion` from the published manifest,
+- your OS / architecture and `dotnet --version`,
+- your generated `my-manifest.json` and the released `reproducible-build-manifest.json`,
+- the `diff` output.
+
+Discrepancies are treated as a security concern — see [SECURITY.md](SECURITY.md).
+
+## Publish a third-party attestation
+
+Independent verification is more valuable when it is *public*. If you have reproduced a
+release, you can publish an attestation that others can find:
+
+- Follow the [Reproducible Builds project](https://reproducible-builds.org/) conventions
+  for recording a successful independent rebuild, or
+- publish a signed attestation via a service such as [vouchsafe.io](https://vouchsafe.io/)
+  referencing the release tag and the manifest hashes you confirmed.
+
+Then link your attestation from a comment on the release, or in a
+`Reproducible-build attestation: v<version>` issue, so future consumers can see the build
+has been independently verified.

--- a/scripts/generate-repro-manifest.py
+++ b/scripts/generate-repro-manifest.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate a reproducible-build manifest for a set of packed NuGet artifacts.
+
+The manifest lists the SHA-256 of every ``.nupkg`` / ``.snupkg`` released, plus the
+SHA-256 of each assembly (``lib/**/*.dll``) inside the package. A third party who
+rebuilds the same tag with the same SDK can regenerate this file and diff it against
+the copy attached to the GitHub Release to confirm the published bits match source.
+
+Emitted per release by ``.github/workflows/release.yaml`` as
+``reproducible-build-manifest.json`` and documented in ``REPRODUCIBLE-BUILD.md``.
+
+Pure standard library — runs anywhere Python 3 does, no jq or NuGet tooling required.
+
+Usage:
+    generate-repro-manifest.py --packages <dir> --out <file.json> \
+        [--repository owner/repo] [--tag v0.0.0] [--commit <sha>] [--sdk <version>]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import zipfile
+
+
+def sha256_bytes(data: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(data)
+    return digest.hexdigest()
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def package_contents(path: str) -> list[dict[str, str]]:
+    """SHA-256 of each assembly under lib/ inside a .nupkg/.snupkg (sorted, stable)."""
+    contents: list[dict[str, str]] = []
+    with zipfile.ZipFile(path) as archive:
+        for name in sorted(archive.namelist()):
+            lowered = name.lower()
+            if lowered.startswith("lib/") and lowered.endswith((".dll", ".pdb")):
+                contents.append({"path": name, "sha256": sha256_bytes(archive.read(name))})
+    return contents
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packages", required=True, help="directory holding the packed artifacts")
+    parser.add_argument("--out", required=True, help="manifest output path")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
+    parser.add_argument("--sdk", default="", help="the .NET SDK version used to build")
+    args = parser.parse_args()
+
+    artifacts = []
+    for entry in sorted(os.listdir(args.packages)):
+        if not entry.endswith((".nupkg", ".snupkg")):
+            continue
+        full = os.path.join(args.packages, entry)
+        artifacts.append(
+            {
+                "file": entry,
+                "sha256": sha256_file(full),
+                "contents": package_contents(full),
+            }
+        )
+
+    if not artifacts:
+        print(f"::error::No .nupkg/.snupkg found in {args.packages}", file=sys.stderr)
+        return 1
+
+    manifest = {
+        "schemaVersion": 1,
+        "repository": args.repository,
+        "tag": args.tag,
+        "commit": args.commit,
+        "sdkVersion": args.sdk,
+        "buildCommand": (
+            "dotnet pack src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj "
+            "-c Release -p:ContinuousIntegrationBuild=true -p:Deterministic=true"
+        ),
+        "artifacts": artifacts,
+    }
+
+    with open(args.out, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(manifest, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+    print(f"Wrote {args.out}: {len(artifacts)} artifact(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the consumer/third-party side of reproducible builds (#102). **Stacked on #93** (base `ci/reproducible-build`) since it extends that PR's `REPRODUCIBLE-BUILD.md`.

## What (non-protected — full CI)

- **`REPRODUCIBLE-BUILD.md`** gains consumer-side sections: the per-release **manifest** (what it records), a copy-paste **verify-a-release** recipe (regenerate → diff `.artifacts` hashes), **file a discrepancy** (issue template + link to SECURITY.md), and **publish a third-party attestation** (Reproducible Builds project / vouchsafe.io conventions).
- **`scripts/generate-repro-manifest.py`** — pure-stdlib Python 3: SHA-256 of every `.nupkg`/`.snupkg` plus each inner `lib/**/*.dll`/`.pdb`, with repo/tag/commit/sdk + the exact build command. Validated locally against a real `dotnet pack` (2 artifacts, 11 inner assemblies).
- **README** — new "Verify the build" section linking the guide.

## AC mapping

| AC | Status |
|---|---|
| `REPRODUCIBLE-BUILD.md`: tooling versions, build command, expected hashes, discrepancy filing | ✅ this PR |
| README "Verify the build" section | ✅ this PR |
| Third-party attestation procedure | ✅ this PR |
| `release.yaml` publishes `reproducible-build-manifest.json` per release | ⏭️ separate protected-file PR (needs admin-bypass), stacked on this — the generator script it calls lands here |

The path deviates from the AC's literal `docs/REPRODUCIBLE-BUILD.md` by keeping the file at repo root, where #93 established it (conventional alongside `SECURITY.md`); one canonical doc rather than a duplicate.

Closes #102
