### PR TITLE
ci: cross-platform/multi-arch test differential (#86)

### DIFF
--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -1,0 +1,121 @@
+name: Cross-Platform Differential
+
+# Stages 2/3 of pr.yaml verify the suite PASSES on each OS. This verifies it passes
+# the SAME WAY on every OS *and* architecture: the same test set runs on linux-x64,
+# linux-arm64, macos-arm64 and windows-x64, and their normalized outcomes are diffed.
+# Any divergence (a test that passes on one platform and fails on another, or a theory
+# whose parameters render differently under a culture-sensitive conversion) fails the run.
+#
+# Tests that are legitimately platform-specific must be tagged with
+# [Trait("Category", "PlatformSpecific")] so they are excluded from the differential.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-differential-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TEST_PROJECT: tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
+  # net10.0 is available on all four runners, giving one comparable framework across
+  # OS/arch. Cross-TFM behaviour is already covered by pr.yaml's full matrix.
+  TEST_TFM: net10.0
+
+jobs:
+  run:
+    name: Test (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-x64
+            os: ubuntu-latest
+          - label: linux-arm64
+            os: ubuntu-24.04-arm
+          - label: macos-arm64
+            os: macos-latest
+          - label: windows-x64
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run tests
+        shell: bash
+        # Exclude PlatformSpecific-tagged tests; they are allowed to differ by platform.
+        run: >
+          dotnet test "$TEST_PROJECT"
+          -c Release
+          --framework "$TEST_TFM"
+          --filter "Category!=PlatformSpecific"
+          --logger "trx;LogFileName=results.trx"
+          --results-directory trx-out
+
+      - name: Upload raw results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: trx-${{ matrix.label }}
+          path: trx-out/results.trx
+          if-no-files-found: error
+
+  compare:
+    name: Diff outcomes across platforms
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Download all results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: trx-*
+          path: trx
+
+      - name: Normalize and diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          labels=(linux-x64 linux-arm64 macos-arm64 windows-x64)
+          ref=linux-x64
+
+          for label in "${labels[@]}"; do
+            python3 scripts/normalize-test-results.py "trx/trx-$label"/*.trx > "norm-$label.txt"
+            echo "$label: $(wc -l < "norm-$label.txt") tests"
+          done
+
+          fail=0
+          for label in "${labels[@]}"; do
+            [ "$label" = "$ref" ] && continue
+            if diff -u "norm-$ref.txt" "norm-$label.txt" > "diff-$label.txt"; then
+              echo "✅ $label matches $ref"
+            else
+              echo "::error::Test outcomes diverge between $ref and $label:"
+              cat "diff-$label.txt"
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Cross-platform differential failed. Tag genuinely platform-specific tests with [Trait(\"Category\", \"PlatformSpecific\")]."
+            exit 1
+          fi
+          echo "All platforms produced identical test outcomes."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
 - Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
   the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
   `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
   between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
   misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
   Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
 - Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
   library's one intentional zero-allocation hot path
   (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
   source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
   `docs/allocation-budget.md` documenting the covered call sites and why streaming
   transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
 ### Changed
 
 ### Deprecated

--- a/docs/cross-platform-differential.md
+++ b/docs/cross-platform-differential.md
@@ -1,0 +1,44 @@
+# Cross-platform / multi-arch differential
+
+`pr.yaml` already runs the test suite on Linux, Windows, and macOS, but it only checks
+that the suite *passes* on each. The
+[`cross-platform-differential.yaml`](../.github/workflows/cross-platform-differential.yaml)
+workflow goes further: it verifies the suite passes **the same way** on every OS *and*
+architecture, and it adds ARM64 coverage that `pr.yaml` lacks.
+
+## What it does
+
+1. Runs the unit test project (`net10.0`, the one framework available on all four runners)
+   on:
+   - **linux-x64** — `ubuntu-latest`
+   - **linux-arm64** — `ubuntu-24.04-arm`
+   - **macos-arm64** — `macos-latest` (Apple Silicon)
+   - **windows-x64** — `windows-latest`
+2. Each job uploads its raw `.trx`.
+3. A compare job normalizes every run to a stable `outcome<TAB>testName` form
+   ([`scripts/normalize-test-results.py`](../scripts/normalize-test-results.py)) and diffs
+   each platform against `linux-x64`.
+4. **Any divergence fails the workflow** with the offending diff.
+
+It triggers on PRs that change `src/**` or `tests/**`, and on manual dispatch.
+
+## What a divergence looks like
+
+A test that passes on x64 but fails on ARM64, or a theory whose parameters render
+differently under a culture-sensitive conversion (e.g. a number or date formatted with the
+current culture), produces a differing line and fails the run. These are exactly the subtle
+bugs a per-OS pass/fail gate misses.
+
+## Platform-specific tests
+
+If a test is *legitimately* platform-specific (path separators, file-system case
+sensitivity, an OS-only API), tag it so the differential excludes it:
+
+```csharp
+[Fact]
+[Trait("Category", "PlatformSpecific")]
+public void Path_handling_uses_the_OS_separator() { /* ... */ }
+```
+
+The workflow runs with `--filter "Category!=PlatformSpecific"`, so tagged tests still run in
+`pr.yaml` but never trip the differential.

--- a/scripts/normalize-test-results.py
+++ b/scripts/normalize-test-results.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Normalize a VSTest ``.trx`` file into a stable, platform-independent text form.
+
+Emits one ``<outcome>\t<testName>`` line per test, sorted by test name, so the output
+of the same test suite run on different OS/architecture combinations can be diffed
+directly. Any divergence — a test that passes on one platform and fails on another, or a
+theory whose parameter rendering differs because of a culture-sensitive conversion —
+shows up as a line difference.
+
+Used by ``.github/workflows/cross-platform-differential.yaml``. Pure standard library.
+
+Usage:
+    normalize-test-results.py <results.trx> [more.trx ...]
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+
+TRX_NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
+
+
+def normalize(trx_paths: list[str]) -> list[str]:
+    seen: dict[str, str] = {}
+    for path in trx_paths:
+        root = ET.parse(path).getroot()
+        for result in root.iter(f"{TRX_NS}UnitTestResult"):
+            name = result.get("testName")
+            outcome = result.get("outcome", "Unknown")
+            if name is None:
+                continue
+            # If the same test somehow appears twice, a Failed/oddoutcome wins over Passed
+            # so a divergence is never masked.
+            if name not in seen or (seen[name] == "Passed" and outcome != "Passed"):
+                seen[name] = outcome
+    return [f"{outcome}\t{name}" for name, outcome in sorted(seen.items())]
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: normalize-test-results.py <results.trx> [more.trx ...]", file=sys.stderr)
+        return 2
+    for line in normalize(sys.argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements #86 — cross-platform / multi-arch differential.

## What

- **`.github/workflows/cross-platform-differential.yaml`** — runs the unit suite (`net10.0`, the one framework on all four runners) on **linux-x64** (`ubuntu-latest`), **linux-arm64** (`ubuntu-24.04-arm`), **macos-arm64** (`macos-latest`, Apple Silicon), and **windows-x64** (`windows-latest`); each uploads its `.trx`; a compare job normalizes all runs and **diffs each platform against linux-x64, failing on any divergence**.
- **`scripts/normalize-test-results.py`** — pure-stdlib: parses `.trx` → sorted `outcome<TAB>testName` lines, so a test that passes on one arch and fails on another (or a theory that renders differently under a culture-sensitive conversion) shows up as a diff.
- **`docs/cross-platform-differential.md`** — flow + the `[Trait("Category","PlatformSpecific")]` opt-out.

## AC mapping

| AC | Where |
|---|---|
| Same test set on linux-x64 / linux-arm64 / macos-arm64 / windows-x64, diff textual outputs | matrix `run` job + `compare` job |
| Any divergence (except tagged platform-specific tests) fails | `diff -u` per platform; `--filter "Category!=PlatformSpecific"` |
| Matrix includes ≥1 ARM64 runner | **two**: `ubuntu-24.04-arm` + `macos-latest` |

## Testing

The normalizer was validated against a real local `net10.0` run of the unit project — 283 tests parsed to 283 stable `Passed<TAB>name` lines. The full four-runner matrix (incl. the hosted ARM64 runners) executes on this PR.

Closes #86
