### PR TITLE
perf: sustained-load GC/allocation profiling harness + workflow (#89)

### DIFF
--- a/.github/workflows/gc-profiling.yaml
+++ b/.github/workflows/gc-profiling.yaml
@@ -1,0 +1,109 @@
+name: GC Profiling
+
+# Sustained-load GC / allocation profiling (issue #89). BDN benchmarks measure single-method
+# micro-perf; this drives a realistic transformer pipeline under continuous load for ~10 min
+# and captures the metrics that only surface over long-running ETL workloads: gen0/1/2
+# collection counts, gen2 & LOH high-water marks, allocation rate, GC pause time.
+#
+# Captures cross-platform EventPipe data (dotnet-counters CSV + dotnet-gcdump heap snapshot +
+# dotnet-trace GC trace) rather than Windows-only ETW/PerfView, so it runs on hosted Linux.
+#
+# Regression gate: scripts/gc-profile-report.py compares the counters against a committed
+# baseline (profiling/gc-baseline.<scenario>.json) and fails on growth beyond tolerance.
+# Until a baseline is committed the run is report-only; commit the first green run's metrics.
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Mondays 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: Pipeline scenario (mixed | linq | buffered)
+        default: mixed
+        type: string
+      duration_seconds:
+        description: Sustained-load duration per scenario (>= 600 recommended)
+        default: '600'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gc-profiling
+  cancel-in-progress: false
+
+jobs:
+  profile:
+    name: Sustained-load GC profile
+    runs-on: ubuntu-latest
+    env:
+      SCENARIO: ${{ github.event.inputs.scenario || 'mixed' }}
+      DURATION: ${{ github.event.inputs.duration_seconds || '600' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install diagnostics tools
+        run: |
+          dotnet tool install -g dotnet-counters
+          dotnet tool install -g dotnet-gcdump
+          dotnet tool install -g dotnet-trace
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Build profiling harness
+        run: dotnet build profiling/Wolfgang.Etl.Transformers.Profiling/Wolfgang.Etl.Transformers.Profiling.csproj -c Release
+
+      - name: Run sustained load + capture traces
+        run: |
+          set -euo pipefail
+          exe=profiling/Wolfgang.Etl.Transformers.Profiling/bin/Release/net10.0/Wolfgang.Etl.Transformers.Profiling
+          mkdir -p artifacts
+
+          # Launch the harness; capture its PID for the diagnostics tools to attach to.
+          "$exe" --duration-seconds "$DURATION" --scenario "$SCENARIO" &
+          pid=$!
+          echo "Harness PID=$pid scenario=$SCENARIO duration=${DURATION}s"
+          sleep 3  # let the diagnostics IPC endpoint come up
+
+          # Collect System.Runtime counters for the whole run.
+          counters_dur=$(printf '%02d:%02d:%02d' $((DURATION/3600)) $(((DURATION%3600)/60)) $((DURATION%60)))
+          dotnet-counters collect -p "$pid" --format csv -o artifacts/counters.csv \
+            --refresh-interval 5 --counters System.Runtime --duration "$counters_dur" &
+          counters_pid=$!
+
+          # ~2 min before the end, grab a heap snapshot (top object types) and a short GC trace
+          # (allocation-tick events -> top allocation sites). Best-effort; never fail the run.
+          if [ "$DURATION" -gt 150 ]; then sleep $((DURATION - 120)); else sleep 5; fi
+          dotnet-gcdump collect -p "$pid" -o artifacts/heap.gcdump || echo "gcdump skipped"
+          dotnet-trace collect -p "$pid" --duration 00:01:00 --profile gc-verbose \
+            -o artifacts/gc.nettrace || echo "trace skipped"
+
+          wait "$counters_pid" || true
+          wait "$pid"
+          echo "Harness exited."
+
+      - name: Report metrics + regression gate
+        run: |
+          set -euo pipefail
+          baseline="profiling/gc-baseline.${SCENARIO}.json"
+          python3 scripts/gc-profile-report.py \
+            --csv artifacts/counters.csv \
+            --out "artifacts/gc-metrics.${SCENARIO}.json" \
+            --baseline "$baseline" \
+            --scenario "$SCENARIO"
+
+      - name: Upload profiling artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gc-profile-${{ env.SCENARIO }}
+          path: artifacts/
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
 - Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
   new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
   load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
   heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
   committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
 - Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
   library's one intentional zero-allocation hot path
   (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
   source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
   `docs/allocation-budget.md` documenting the covered call sites and why streaming
   transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 
 ### Changed
 

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -41,6 +41,9 @@
     <Project Path="examples/BufferedPipeline/BufferedPipeline.csproj" />
     <Project Path="examples/LinqOps/LinqOps.csproj" />
   </Folder>
+  <Folder Name="/profiling/">
+    <Project Path="profiling/Wolfgang.Etl.Transformers.Profiling/Wolfgang.Etl.Transformers.Profiling.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />
   </Folder>

--- a/docs/gc-profiling.md
+++ b/docs/gc-profiling.md
@@ -1,0 +1,50 @@
+# Sustained-load GC / allocation profiling
+
+BenchmarkDotNet (`benchmarks/`) measures single-method micro-performance. The
+[`GC Profiling`](../.github/workflows/gc-profiling.yaml) workflow answers a different
+question: **how does the library behave under continuous, long-running load?** — the gen0/1/2
+promotion, LOH pressure, and allocation-rate characteristics that only appear in a
+server/ETL process that runs for hours.
+
+## Components
+
+| Piece | Role |
+| --- | --- |
+| [`profiling/Wolfgang.Etl.Transformers.Profiling`](../profiling/Wolfgang.Etl.Transformers.Profiling) | Console harness that drives a representative transformer pipeline in a tight loop for a configurable duration (`--duration-seconds`, `--scenario mixed\|linq\|buffered`). Server GC enabled. |
+| `dotnet-counters` | Collects `System.Runtime` GC counters to CSV over the whole run. |
+| `dotnet-gcdump` | Heap snapshot near the end — inspect **top object types on the heap** offline. |
+| `dotnet-trace` (`gc-verbose`) | Short GC trace — inspect **top allocation sites** (allocation-tick events) offline. |
+| [`scripts/gc-profile-report.py`](../scripts/gc-profile-report.py) | Summarizes the counters CSV into headline metrics and gates against a baseline. |
+
+EventPipe tools are used instead of Windows-only ETW/PerfView so the whole thing runs on a
+hosted Linux runner. The `.gcdump` and `.nettrace` artifacts open in Visual Studio /
+PerfView / `dotnet-trace report` for the "top allocation sites / top object types" drill-down.
+
+## Metrics captured
+
+`gen0/1/2 collections`, `gen2` & `LOH` heap high-water marks, `total allocated bytes` +
+`allocation rate (B/s)`, `GC pause seconds`, `ThreadPool queue` high-water mark, and lock
+contentions. The **gated** metrics (fail the build on regression past tolerance, default
+25%) are: gen2 collections, total allocated bytes, allocation rate, gen2 heap max, LOH heap
+max.
+
+## The baseline
+
+The gate compares against `profiling/gc-baseline.<scenario>.json`. **No baseline is committed
+initially** — the first run is report-only and prints its metrics. Commit that run's
+`gc-metrics.<scenario>.json` (from the workflow artifact) as
+`profiling/gc-baseline.<scenario>.json` to arm the gate. Refresh it deliberately when an
+intentional change shifts the numbers.
+
+Baselines are runner-specific: capture them from the same CI environment the gate runs in,
+not from a local machine (Server GC, core count, and OS all affect the absolute numbers).
+
+## Running locally
+
+```bash
+dotnet build profiling/Wolfgang.Etl.Transformers.Profiling -c Release
+exe=profiling/Wolfgang.Etl.Transformers.Profiling/bin/Release/net10.0/Wolfgang.Etl.Transformers.Profiling
+"$exe" --duration-seconds 60 --scenario mixed &
+dotnet-counters collect -p $! --format csv -o counters.csv --counters System.Runtime --duration 00:01:00
+python3 scripts/gc-profile-report.py --csv counters.csv --out metrics.json --scenario mixed
+```

--- a/profiling/Wolfgang.Etl.Transformers.Profiling/Program.cs
+++ b/profiling/Wolfgang.Etl.Transformers.Profiling/Program.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Transformers;
+
+namespace Wolfgang.Etl.Transformers.Profiling;
+
+/// <summary>
+/// Sustained-load driver for GC / allocation profiling (issue #89). Runs a representative
+/// transformer pipeline in a tight loop for a configurable duration so an external profiler
+/// (dotnet-counters / dotnet-trace / dotnet-gcdump) can characterise gen0/1/2 promotion,
+/// LOH pressure, and allocation rate under continuous throughput.
+/// </summary>
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        var durationSeconds = GetInt(args, "--duration-seconds", 600);
+        var batchSize = GetInt(args, "--batch-size", 100_000);
+        var scenario = GetString(args, "--scenario", "mixed");
+
+        Console.WriteLine(string.Create(
+            CultureInfo.InvariantCulture,
+            $"Profiling scenario='{scenario}' duration={durationSeconds}s batch={batchSize} PID={Environment.ProcessId} ServerGC={System.Runtime.GCSettings.IsServerGC}"));
+
+        var stopwatch = Stopwatch.StartNew();
+        long itemsProcessed = 0;
+        long batches = 0;
+
+        while (stopwatch.Elapsed.TotalSeconds < durationSeconds)
+        {
+            itemsProcessed += await RunOnceAsync(scenario, batchSize).ConfigureAwait(false);
+            batches++;
+
+            if (batches % 50 == 0)
+            {
+                Console.WriteLine(string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"[{stopwatch.Elapsed:hh\\:mm\\:ss}] batches={batches} items={itemsProcessed:N0} gen0={GC.CollectionCount(0)} gen1={GC.CollectionCount(1)} gen2={GC.CollectionCount(2)}"));
+            }
+        }
+
+        stopwatch.Stop();
+        Console.WriteLine(string.Create(
+            CultureInfo.InvariantCulture,
+            $"Done. batches={batches} items={itemsProcessed:N0} elapsed={stopwatch.Elapsed} gen0={GC.CollectionCount(0)} gen1={GC.CollectionCount(1)} gen2={GC.CollectionCount(2)}"));
+        return 0;
+    }
+
+
+    private static async Task<long> RunOnceAsync(string scenario, int count)
+    {
+        long consumed = 0;
+
+        switch (scenario)
+        {
+            case "buffered":
+            {
+                var buffered = new BufferedTransformer<int>(500);
+                await foreach (var _ in buffered.TransformAsync(SourceAsync(count)).ConfigureAwait(false))
+                {
+                    consumed++;
+                }
+
+                break;
+            }
+
+            case "linq":
+            {
+                var where = new WhereTransformer<int>(i => i % 2 == 0);
+                var select = new SelectTransformer<int, int>(i => i * 2);
+                var distinct = new DistinctByTransformer<int, int>(i => i % 4096);
+                var chunk = new ChunkTransformer<int>(256);
+
+                var pipeline = chunk.TransformAsync(
+                    distinct.TransformAsync(
+                        select.TransformAsync(
+                            where.TransformAsync(SourceAsync(count)))));
+
+                await foreach (var batch in pipeline.ConfigureAwait(false))
+                {
+                    consumed += batch.Count;
+                }
+
+                break;
+            }
+
+            default:
+            {
+                // "mixed": filter -> project (widening) -> buffer -> chunk, the shape a real
+                // streaming ETL stage tends to have.
+                var where = new WhereTransformer<int>(i => i % 3 != 0);
+                var select = new SelectTransformer<int, long>(i => (long)i * i);
+                var buffered = new BufferedTransformer<long>(1000);
+                var chunk = new ChunkTransformer<long>(512);
+
+                var pipeline = chunk.TransformAsync(
+                    buffered.TransformAsync(
+                        select.TransformAsync(
+                            where.TransformAsync(SourceAsync(count)))));
+
+                await foreach (var batch in pipeline.ConfigureAwait(false))
+                {
+                    consumed += batch.Count;
+                }
+
+                break;
+            }
+        }
+
+        return consumed;
+    }
+
+
+    // Synchronously-completing async source: maximises throughput so the pressure measured
+    // is the transformers' own, not a scheduler's.
+    private static async IAsyncEnumerable<int> SourceAsync(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+
+    private static int GetInt(string[] args, string name, int fallback)
+    {
+        var raw = GetString(args, name, fallback: null);
+        return raw is not null && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : fallback;
+    }
+
+
+    private static string GetString(string[] args, string name, string? fallback)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], name, StringComparison.Ordinal))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return fallback!;
+    }
+}

--- a/profiling/Wolfgang.Etl.Transformers.Profiling/Wolfgang.Etl.Transformers.Profiling.csproj
+++ b/profiling/Wolfgang.Etl.Transformers.Profiling/Wolfgang.Etl.Transformers.Profiling.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Sustained-load profiling harness for GC/allocation characterisation (issue #89).
+    Not a benchmark (that's the Benchmarks project) and not shipped — it drives the
+    transformers under continuous high-volume load so dotnet-counters / dotnet-trace /
+    dotnet-gcdump can capture gen0/1/2, LOH, and allocation-rate behaviour over ~10 min.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/gc-profile-report.py
+++ b/scripts/gc-profile-report.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Summarize a dotnet-counters GC CSV into headline metrics and gate against a baseline.
+
+Parses the CSV produced by ``dotnet-counters collect --format csv`` (System.Runtime
+meters) over a sustained-load run and derives the metrics that matter under long-running
+ETL workloads: gen0/1/2 collection counts, gen2 & LOH heap high-water marks, total bytes
+allocated + allocation rate, total GC pause time, ThreadPool queue high-water mark, and
+lock-contention count.
+
+Counter names carry the refresh interval in their text (``... / 5 sec``), so metrics are
+matched by stable substrings rather than exact names.
+
+Writes the metrics as JSON (``--out``). If ``--baseline`` points at an existing metrics
+file, each gated metric is compared and the script exits non-zero when any exceeds
+``baseline * (1 + tolerance)``. With no baseline (first run), it is report-only and prints
+the measured metrics as the baseline to commit.
+
+Used by ``.github/workflows/gc-profiling.yaml``. Pure standard library.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime
+
+# Metric key -> (name substring, optional generation tag, aggregation)
+# aggregation: "sum" for per-interval increments, "max" for snapshot gauges.
+SPECS = {
+    "gen0_collections": ("dotnet.gc.collections", "generation=gen0", "sum"),
+    "gen1_collections": ("dotnet.gc.collections", "generation=gen1", "sum"),
+    "gen2_collections": ("dotnet.gc.collections", "generation=gen2", "sum"),
+    "total_allocated_bytes": ("dotnet.gc.heap.total_allocated", None, "sum"),
+    "gc_pause_seconds": ("dotnet.gc.pause.time", None, "sum"),
+    "lock_contentions": ("dotnet.monitor.lock_contentions", None, "sum"),
+    "gen2_heap_max_bytes": ("dotnet.gc.last_collection.heap.size", "generation=gen2", "max"),
+    "loh_heap_max_bytes": ("dotnet.gc.last_collection.heap.size", "generation=loh", "max"),
+    "threadpool_queue_max": ("dotnet.thread_pool.queue.length", None, "max"),
+    "working_set_max_bytes": ("dotnet.process.memory.working_set", None, "max"),
+}
+
+# Metrics that fail the build when they regress past the baseline. Heap/allocation growth
+# and extra collections are real regressions; queue depth and working set are informational.
+GATED = {
+    "gen2_collections",
+    "total_allocated_bytes",
+    "allocation_rate_bytes_per_sec",
+    "gen2_heap_max_bytes",
+    "loh_heap_max_bytes",
+}
+
+
+def parse(csv_path: str) -> dict[str, float]:
+    sums: dict[str, float] = {k: 0.0 for k, v in SPECS.items() if v[2] == "sum"}
+    maxes: dict[str, float] = {k: 0.0 for k, v in SPECS.items() if v[2] == "max"}
+    timestamps: list[datetime] = []
+
+    with open(csv_path, encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        for row in reader:
+            if len(row) < 5:
+                continue
+            ts_raw, _provider, name, _ctype, value_raw = row[0], row[1], row[2], row[3], row[4]
+            try:
+                value = float(value_raw)
+            except ValueError:
+                continue
+            try:
+                timestamps.append(datetime.strptime(ts_raw, "%m/%d/%Y %H:%M:%S"))
+            except ValueError:
+                pass
+            for key, (substr, gen, agg) in SPECS.items():
+                if substr in name and (gen is None or gen in name):
+                    if agg == "sum":
+                        sums[key] += value
+                    else:
+                        maxes[key] = max(maxes[key], value)
+
+    metrics: dict[str, float] = {}
+    metrics.update({k: round(v, 3) for k, v in sums.items()})
+    metrics.update({k: round(v, 3) for k, v in maxes.items()})
+
+    duration = 0.0
+    if len(timestamps) >= 2:
+        duration = (max(timestamps) - min(timestamps)).total_seconds()
+    metrics["duration_seconds"] = round(duration, 1)
+    metrics["allocation_rate_bytes_per_sec"] = round(
+        metrics["total_allocated_bytes"] / duration if duration > 0 else 0.0, 1
+    )
+    return metrics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, help="dotnet-counters CSV path")
+    parser.add_argument("--out", required=True, help="metrics JSON output path")
+    parser.add_argument("--baseline", default="", help="baseline metrics JSON to gate against")
+    parser.add_argument("--scenario", default="", help="scenario label recorded in the output")
+    parser.add_argument("--tolerance", type=float, default=0.25, help="allowed fractional growth")
+    args = parser.parse_args()
+
+    metrics = parse(args.csv)
+    if args.scenario:
+        metrics["scenario"] = args.scenario
+
+    with open(args.out, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(metrics, handle, indent=2)
+        handle.write("\n")
+
+    print(f"=== GC profile metrics ({args.scenario or 'run'}) ===")
+    for key, value in metrics.items():
+        print(f"  {key}: {value}")
+
+    baseline = None
+    if args.baseline:
+        try:
+            with open(args.baseline, encoding="utf-8") as handle:
+                baseline = json.load(handle)
+        except FileNotFoundError:
+            baseline = None
+
+    if not baseline:
+        print("\nNo baseline present - report-only. Commit the metrics above as the baseline.")
+        return 0
+
+    print(f"\n=== Regression gate (tolerance {args.tolerance:.0%}) ===")
+    regressed = []
+    for key in sorted(GATED):
+        base = baseline.get(key)
+        current = metrics.get(key)
+        if base is None or current is None:
+            continue
+        limit = base * (1 + args.tolerance)
+        status = "OK"
+        if base > 0 and current > limit:
+            status = "REGRESSED"
+            regressed.append((key, base, current, limit))
+        elif base == 0 and current > 0:
+            status = "REGRESSED"
+            regressed.append((key, base, current, 0))
+        print(f"  {key}: base={base} current={current} limit={round(limit, 1)} -> {status}")
+
+    if regressed:
+        print("\n::error::GC profile regressed vs baseline:")
+        for key, base, current, limit in regressed:
+            print(f"::error::  {key}: {current} exceeds limit {round(limit, 1)} (baseline {base})")
+        return 1
+
+    print("\nAll gated metrics within tolerance.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements #89 — sustained-load GC / allocation profiling.

## What

- **`profiling/Wolfgang.Etl.Transformers.Profiling`** — console harness (Server GC) that drives a representative transformer pipeline (`--scenario mixed|linq|buffered`) in a tight loop for `--duration-seconds`, so a profiler can characterise behaviour under continuous throughput.
- **`.github/workflows/gc-profiling.yaml`** — scheduled (weekly) + `workflow_dispatch`. Runs the harness ~10 min and captures **cross-platform EventPipe** data: `dotnet-counters` CSV (whole run), `dotnet-gcdump` heap snapshot (top object types), `dotnet-trace gc-verbose` (top allocation sites). Uploads all as artifacts.
- **`scripts/gc-profile-report.py`** — parses the counters CSV into headline metrics (gen0/1/2 collections, gen2 & LOH high-water, total allocated + **allocation rate**, GC pause, ThreadPool queue) and **gates against a committed baseline**, failing on growth beyond tolerance (default 25%).
- **`docs/gc-profiling.md`** — components, metrics, baseline workflow.

Uses EventPipe (Linux-friendly) rather than Windows-only ETW/PerfView; the `.gcdump`/`.nettrace` artifacts still open in PerfView/VS for the allocation-site / heap-type drill-down the AC asks for.

## AC mapping

| AC | Where |
|---|---|
| Scheduled workflow, realistic workload ≥10 min/scenario, captures traces | `gc-profiling.yaml` (600s default; counters + gcdump + trace) |
| Reports top allocation sites, top heap object types, gen2/LOH frequency | `.nettrace` (alloc sites) + `.gcdump` (heap types) artifacts; counters CSV → gen2/LOH metrics |
| Regressions vs baseline fail the workflow | `gc-profile-report.py` gate vs `profiling/gc-baseline.<scenario>.json` |

## Baseline note

No baseline is committed yet — the gate is **report-only** on the first run and prints its metrics. Commit that run's `gc-metrics.<scenario>.json` (from the artifact) as `profiling/gc-baseline.<scenario>.json` to arm the gate. Baselines are runner-specific, so they must come from CI, not a dev box.

## Testing

Harness builds clean (analyzers-as-errors). The parser was validated against a **real local `dotnet-counters` capture** of an 18s `mixed` run — extracted 225 gen0 collections, ~35 MB/s allocation rate, gen2/LOH = 0; both the report-only and gate paths verified.

Closes #89
