### PR TITLE
test: shadow-testing sample workloads + nightly regression gate (#77)

### DIFF
--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -1,0 +1,118 @@
+name: Shadow Testing
+
+# Nightly shadow testing (issue #77). Runs the realistic consumer workloads under
+# samples/ShadowWorkloads (variable page sizes, concurrent enumeration, mixed sync/async
+# sources, bursty windows) and compares their BDN time/allocation results against a
+# committed golden baseline captured from a release. A regression beyond threshold fails
+# the run and opens/updates a tracking issue.
+#
+# Distinct from benchmarks.yaml (curated micro-perf trend) and pr-benchmarks.yaml (per-PR
+# gate): this replays production-shaped traffic against the latest commit.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # nightly 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      time_threshold:
+        description: Max % slower before a benchmark counts as regressed
+        default: '20'
+        type: string
+      alloc_threshold:
+        description: Max % more allocations before a benchmark counts as regressed
+        default: '50'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-testing
+  cancel-in-progress: false
+
+env:
+  BENCH_DIR: samples/ShadowWorkloads
+  BASELINE_DIR: samples/shadow-baseline
+  TIME_THRESHOLD: ${{ github.event.inputs.time_threshold || '20' }}
+  ALLOC_THRESHOLD: ${{ github.event.inputs.alloc_threshold || '50' }}
+
+jobs:
+  shadow:
+    name: Replay shadow workloads
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write  # Open/update the regression tracking issue
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run shadow workloads
+        working-directory: ${{ env.BENCH_DIR }}
+        run: dotnet run -c Release -- --filter "*" --job short --memory --exporters json
+
+      - name: Compare against baseline
+        id: compare
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/compare-benchmarks.py \
+            --base-dir "$BASELINE_DIR" \
+            --head-dir "$BENCH_DIR/BenchmarkDotNet.Artifacts/results" \
+            --time-threshold "$TIME_THRESHOLD" \
+            --alloc-threshold "$ALLOC_THRESHOLD" \
+            --out "$RUNNER_TEMP/shadow-report.md" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Upload shadow results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: shadow-results
+          path: |
+            ${{ env.BENCH_DIR }}/BenchmarkDotNet.Artifacts/results/
+            ${{ runner.temp }}/shadow-report.md
+          if-no-files-found: warn
+
+      - name: Open or update regression issue
+        if: steps.compare.outputs.regressed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          marker='<!-- shadow-regression -->'
+          title='Shadow-test regression detected'
+          {
+            echo "$marker"
+            echo "The nightly shadow workloads regressed beyond threshold on \`${{ github.sha }}\`."
+            echo ""
+            cat "$RUNNER_TEMP/shadow-report.md"
+            echo ""
+            echo "[Workflow run]($RUN_URL)"
+          } > "$RUNNER_TEMP/issue-body.md"
+
+          existing=$(gh issue list --repo "$REPO" --state open --search "$marker in:body" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body-file "$RUNNER_TEMP/issue-body.md"
+            echo "Commented on existing issue #$existing"
+          else
+            gh issue create --repo "$REPO" --title "$title" \
+              --body-file "$RUNNER_TEMP/issue-body.md" \
+              --label "maintenance - performance"
+          fi
+
+      - name: Fail on regression
+        if: steps.compare.outputs.regressed == 'true'
+        run: |
+          echo "::error::Shadow workloads regressed beyond threshold (time > ${TIME_THRESHOLD}% or alloc > ${ALLOC_THRESHOLD}%). See the tracking issue and artifact."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
+  `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
+  count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))
+
 - Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
   page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
   public transformers, and a nightly `Shadow Testing` workflow replays them against a
   committed golden baseline, opening a tracking issue and failing on regression beyond
   threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
-- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
-  on the PR head and its base commit, posts a sticky delta-table comment, and fails
-  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
-  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
-  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Security-grade SAST beyond CodeQL: a `semgrep.yaml` workflow runs Semgrep OSS
+  (p/csharp, p/security-audit, p/secrets), diff-aware with SARIF upload to code scanning, plus
+  `docs/sast.md`. ([#78](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/78))
+
+- ABI-compatibility gate: `EnablePackageValidation` with a pinned
+  `PackageValidationBaselineVersion` fails the build on a breaking public-API change versus
+  the last published release. ([#83](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/83))
+
+- Concurrency / race-condition testing: a `Tests.Concurrency` project defines interleaving
+  scenarios (concurrent enumeration of one transformer, BufferedTransformer producer/consumer,
+  cancellation mid-enumeration) run both as an xunit stress gate and as Microsoft Coyote
+  systematic-exploration entry points. A weekly `Concurrency (Coyote)` workflow runs the
+  stress gate (blocking) and Coyote exploration (non-blocking, traces uploaded). Documented
+  in `docs/concurrency-testing.md`. ([#84](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/84))
+
+- Supply-chain hardening: releases now emit a Sigstore-backed SLSA build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable via `gh attestation
+  verify`) and support secret-gated NuGet author-signing (inert until a code-signing
+  certificate is configured; NuGet.org repository signing applies regardless). SECURITY.md
+  documents the full consumer verification chain (signature → provenance → SBOM →
+  reproducible build). ([#85](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/85))
+
+- Cross-platform/multi-arch differential: a `Cross-Platform Differential` workflow runs
+  the test suite on linux-x64, linux-arm64, macos-arm64, and windows-x64, normalizes the
+  `.trx` outcomes (`scripts/normalize-test-results.py`), and fails on any divergence
+  between platforms — adding ARM64 coverage and catching bugs a per-OS pass/fail gate
+  misses. Platform-specific tests opt out via `[Trait("Category","PlatformSpecific")]`.
+  Documented in `docs/cross-platform-differential.md`. ([#86](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/86))
+
+- Snapshot / approval testing: a `Tests.Snapshots` project uses Verify to lock stable
+  transformer outputs against committed snapshots, plus `docs/snapshot-testing.md`. ([#87](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/87))
+
+- Sustained-load GC/allocation profiling: a scheduled `GC Profiling` workflow drives a
+  new `Wolfgang.Etl.Transformers.Profiling` harness under ~10 min of continuous pipeline
+  load, captures cross-platform EventPipe data (`dotnet-counters` CSV + `dotnet-gcdump`
+  heap snapshot + `dotnet-trace` GC trace), and gates gen2/LOH/allocation-rate against a
+  committed baseline via `scripts/gc-profile-report.py`. Documented in `docs/gc-profiling.md`. ([#89](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/89))
+
+- Native-AOT / trim smoke: an `AotConsumer` roots every public call site and an `aot.yaml`
+  workflow publishes it with `PublishAot` / `PublishTrimmed` / `IlcTreatWarningsAsErrors`,
+  failing on any IL trim/AOT warning. ([#90](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/90))
+
+- Globalization / culture-invariance test matrix: `GlobalizationInvarianceTests` runs the
+  suite under en-US, tr-TR, de-DE, zh-CN, ar-SA and ja-JP to catch culture-sensitive
+  behaviour (numeric/date formatting, ordinal vs culture-aware comparison), plus
+  `docs/globalization.md`. ([#92](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/92))
+
+- Reproducible-build verification: a `Reproducible Build` workflow packs the
+  project on Ubuntu and Windows and compares output hashes — same-OS/SDK
+  determinism is the guarantee; cross-OS divergence is reported as an advisory
+  warning (not a failure) pending a tracked follow-up. Plus `REPRODUCIBLE-BUILD.md`
+  documenting the guarantee and how a third party can verify a published package
+  against source on the same OS. ([#93](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/93))
+
 - Allocation-budget enforcement: a net10.0 `Tests.Allocation` project asserts the
   library's one intentional zero-allocation hot path
   (`PassThroughTransformer<T>.TransformAsync(IAsyncEnumerable<T>)` returns the
   source by reference, 0 bytes) via `GC.GetAllocatedBytesForCurrentThread`, plus
   `docs/allocation-budget.md` documenting the covered call sites and why streaming
   transformers are deliberately out of scope. ([#94](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/94))
+
+- Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
+  on the PR head and its base commit, posts a sticky delta-table comment, and fails
+  the PR when a benchmark is >20% slower or allocates >50% more (overridable with the
+  `perf-impact-acknowledged` label). Backed by `scripts/compare-benchmarks.py` and
+  documented in `docs/pr-benchmarks.md`. ([#101](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/101))
+
+- Consumer-side reproducible-build verification: `REPRODUCIBLE-BUILD.md` now documents
+  how a third party regenerates and diffs the per-release
+  `reproducible-build-manifest.json` (produced by `scripts/generate-repro-manifest.py`),
+  files a discrepancy, and publishes an independent verification attestation; a "Verify
+  the build" section links it from the README. ([#102](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/102))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Shadow testing: `samples/ShadowWorkloads` models realistic production traffic (variable
+  page sizes, concurrent enumeration, mixed sync/async sources, bursty windows) across the
+  public transformers, and a nightly `Shadow Testing` workflow replays them against a
+  committed golden baseline, opening a tracking issue and failing on regression beyond
+  threshold. Documented in `docs/shadow-testing.md`. ([#77](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/77))
 - Per-PR benchmark regression gate: a `PR Benchmarks` workflow runs BenchmarkDotNet
   on the PR head and its base commit, posts a sticky delta-table comment, and fails
   the PR when a benchmark is >20% slower or allocates >50% more (overridable with the

--- a/ETL-Transformers.slnx
+++ b/ETL-Transformers.slnx
@@ -41,6 +41,9 @@
     <Project Path="examples/BufferedPipeline/BufferedPipeline.csproj" />
     <Project Path="examples/LinqOps/LinqOps.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ShadowWorkloads/ShadowWorkloads.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj" />
   </Folder>

--- a/docs/shadow-testing.md
+++ b/docs/shadow-testing.md
@@ -1,0 +1,50 @@
+# Shadow testing
+
+Unit and property tests prove the behavioural contract under *synthetic* input. Shadow
+testing replays **realistic production traffic shapes** against each new commit and compares
+latency/allocation against a golden baseline, catching performance and allocation
+regressions that only surface under real usage.
+
+## The sample workloads
+
+[`samples/ShadowWorkloads`](../samples/ShadowWorkloads) is a BenchmarkDotNet consumer that
+models how the transformers are actually used. Each scenario doubles as runnable "real usage"
+documentation:
+
+| Scenario | Shape it models | Transformers exercised |
+| --- | --- | --- |
+| `VariableSizeStreamingBenchmarks` | SQL/HTTP paging with wildly variable page sizes | `Where`, `Select`, `Chunk` |
+| `ConcurrentEnumerationBenchmarks` | A server enumerating many pipelines in parallel | `Buffered`, `Where` |
+| `MixedSourceBenchmarks` | Enrichment stage over a mixed sync/async source | `Select` (async), `SelectMany`, `Distinct` |
+| `BurstyWindowBenchmarks` | Bounded take with skip/backoff and an observing tap | `SkipWhile`, `Skip`, `Take`, `ProgressReporting` |
+
+Run them locally with:
+
+```bash
+dotnet run -c Release --project samples/ShadowWorkloads -- --filter "*" --job short --memory
+```
+
+## The nightly workflow
+
+[`shadow.yaml`](../.github/workflows/shadow.yaml) runs nightly (and on manual dispatch):
+
+1. Runs every workload with BenchmarkDotNet (`--memory` for GC/allocation stats).
+2. Compares the results against the committed golden baseline
+   ([`samples/shadow-baseline`](../samples/shadow-baseline)) via
+   [`scripts/compare-benchmarks.py`](../scripts/compare-benchmarks.py).
+3. If any workload regresses beyond threshold (default **>20% slower** or **>50% more
+   allocations**, configurable per run via workflow inputs), it **opens or updates a tracking
+   issue** and **fails the run**.
+
+Until a baseline is committed, the run is report-only. See
+[`samples/shadow-baseline/README.md`](../samples/shadow-baseline/README.md) for how to seed
+and refresh it.
+
+## Relationship to the other perf workflows
+
+| Workflow | When | What |
+| --- | --- | --- |
+| `benchmarks.yaml` | push to `main` | Curated micro-perf trend chart |
+| `pr-benchmarks.yaml` | per PR | Gate PR head vs its base |
+| **`shadow.yaml`** | nightly | Replay realistic consumer workloads vs a golden baseline |
+| `gc-profiling.yaml` | weekly | Sustained-load GC/allocation profile |

--- a/samples/ShadowWorkloads/BurstyWindowBenchmarks.cs
+++ b/samples/ShadowWorkloads/BurstyWindowBenchmarks.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.Transformers;
+
+namespace Wolfgang.Etl.Transformers.ShadowWorkloads;
+
+/// <summary>
+/// A bursty source consumed through the windowing/tap operators — the shape of a bounded
+/// take with skip/backoff and an observing tap. Exercises SkipWhile, Skip, Take, and
+/// ProgressReportingTransformer.
+/// </summary>
+[MemoryDiagnoser]
+public class BurstyWindowBenchmarks
+{
+    [Params(50_000)]
+    public int ItemCount { get; set; }
+
+
+    [Benchmark]
+    public async Task<long> SkipWhileSkipTakeProgress()
+    {
+        long observed = 0;
+        var skipWhile = new SkipWhileTransformer<int>(i => i < 10);
+        var skip = new SkipTransformer<int>(5);
+        var take = new TakeTransformer<int>(ItemCount - 100);
+        var progress = new ProgressReportingTransformer<int>(_ => { });
+
+        var pipeline = progress.TransformAsync(
+            take.TransformAsync(
+                skip.TransformAsync(
+                    skipWhile.TransformAsync(Sources.Jittered(ItemCount, asyncEvery: 4096)))));
+        await foreach (var _ in pipeline.ConfigureAwait(false))
+        {
+            observed++;
+        }
+
+        return observed;
+    }
+}

--- a/samples/ShadowWorkloads/ConcurrentEnumerationBenchmarks.cs
+++ b/samples/ShadowWorkloads/ConcurrentEnumerationBenchmarks.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.Transformers;
+
+namespace Wolfgang.Etl.Transformers.ShadowWorkloads;
+
+/// <summary>
+/// Many pipelines enumerated concurrently — the shape of a server handling parallel
+/// requests. Exercises BufferedTransformer under contention plus Where.
+/// </summary>
+[MemoryDiagnoser]
+public class ConcurrentEnumerationBenchmarks
+{
+    [Params(8)]
+    public int Concurrency { get; set; }
+
+
+    [Params(20_000)]
+    public int ItemsPerWorker { get; set; }
+
+
+    [Benchmark]
+    public async Task<long> ConcurrentBufferedPipelines()
+    {
+        var tasks = new Task<long>[Concurrency];
+        for (var worker = 0; worker < Concurrency; worker++)
+        {
+            tasks[worker] = RunWorkerAsync(ItemsPerWorker);
+        }
+
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        long total = 0;
+        foreach (var result in results)
+        {
+            total += result;
+        }
+
+        return total;
+    }
+
+
+    private static async Task<long> RunWorkerAsync(int count)
+    {
+        long seen = 0;
+        var buffered = new BufferedTransformer<int>(500);
+        var where = new WhereTransformer<int>(i => i % 3 != 0);
+
+        var pipeline = where.TransformAsync(buffered.TransformAsync(Sources.Range(count)));
+        await foreach (var _ in pipeline.ConfigureAwait(false))
+        {
+            seen++;
+        }
+
+        return seen;
+    }
+}

--- a/samples/ShadowWorkloads/MixedSourceBenchmarks.cs
+++ b/samples/ShadowWorkloads/MixedSourceBenchmarks.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.Transformers;
+
+namespace Wolfgang.Etl.Transformers.ShadowWorkloads;
+
+/// <summary>
+/// A mixed sync/async source through an async-shaped selector, fan-out, and dedup — the
+/// shape of enrichment stages that occasionally await I/O. Exercises Select (async),
+/// SelectMany, and Distinct.
+/// </summary>
+[MemoryDiagnoser]
+public class MixedSourceBenchmarks
+{
+    [Params(50_000)]
+    public int ItemCount { get; set; }
+
+
+    [Benchmark]
+    public async Task<long> AsyncSelectorSelectManyDistinct()
+    {
+        var select = new SelectTransformer<int, int>(i => new ValueTask<int>(i % 1000));
+        var selectMany = new SelectManyTransformer<int, int>(i => Enumerable.Range(0, i % 4));
+        var distinct = new DistinctTransformer<int>();
+
+        long count = 0;
+        var pipeline = distinct.TransformAsync(
+            selectMany.TransformAsync(
+                select.TransformAsync(Sources.Jittered(ItemCount, asyncEvery: 512))));
+        await foreach (var _ in pipeline.ConfigureAwait(false))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/samples/ShadowWorkloads/Program.cs
+++ b/samples/ShadowWorkloads/Program.cs
@@ -1,0 +1,11 @@
+using BenchmarkDotNet.Running;
+
+// Shadow-testing entry point. `dotnet run -c Release -- --filter "*"` runs every scenario.
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);
+
+// Named type so BenchmarkSwitcher.FromAssembly has a stable anchor (top-level Program).
+internal sealed partial class Program
+{
+}

--- a/samples/ShadowWorkloads/ShadowWorkloads.csproj
+++ b/samples/ShadowWorkloads/ShadowWorkloads.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Shadow-testing sample consumer (issue #77). Unlike benchmarks/ (curated micro-perf),
+    these model realistic production traffic shapes - variable batch sizes, concurrent
+    enumeration, mixed sync/async sources, retry/backoff - and double as "real usage"
+    documentation. Run nightly by shadow.yaml and compared against a golden baseline.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Transformers\Wolfgang.Etl.Transformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ShadowWorkloads/Sources.cs
+++ b/samples/ShadowWorkloads/Sources.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.Transformers.ShadowWorkloads;
+
+/// <summary>
+/// Async sequence shapes that model realistic production traffic for the shadow workloads.
+/// </summary>
+internal static class Sources
+{
+    /// <summary>A synchronously-completing source of <paramref name="count"/> integers.</summary>
+    public static async IAsyncEnumerable<int> Range(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+
+    /// <summary>
+    /// A mostly-synchronous source that forces a real asynchronous hop every
+    /// <paramref name="asyncEvery"/> items — modelling a source that buffers locally but
+    /// periodically waits on I/O (paging, retry/backoff).
+    /// </summary>
+    public static async IAsyncEnumerable<int> Jittered(int count, int asyncEvery)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            if (asyncEvery > 0 && i % asyncEvery == 0)
+            {
+                await Task.Yield();
+            }
+
+            yield return i;
+        }
+    }
+}

--- a/samples/ShadowWorkloads/VariableSizeStreamingBenchmarks.cs
+++ b/samples/ShadowWorkloads/VariableSizeStreamingBenchmarks.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.Transformers;
+
+namespace Wolfgang.Etl.Transformers.ShadowWorkloads;
+
+/// <summary>
+/// Paged extraction with wildly variable page sizes — the shape of SQL/HTTP paging where
+/// each page returns an unpredictable count. Exercises Where → Select → Chunk.
+/// </summary>
+[MemoryDiagnoser]
+public class VariableSizeStreamingBenchmarks
+{
+    private int[] _pageSizes = Array.Empty<int>();
+
+
+    [Params(50)]
+    public int PageCount { get; set; }
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Deterministic pseudo-variable sizes (1..~20k) — no RNG, so BDN stays reproducible.
+        _pageSizes = new int[PageCount];
+        for (var i = 0; i < PageCount; i++)
+        {
+            _pageSizes[i] = 1 + ((i * 7919) % 20000);
+        }
+    }
+
+
+    [Benchmark]
+    public async Task<long> WhereSelectChunkOverVariablePages()
+    {
+        long total = 0;
+        foreach (var size in _pageSizes)
+        {
+            var where = new WhereTransformer<int>(i => (i & 1) == 0);
+            var select = new SelectTransformer<int, long>(i => (long)i);
+            var chunk = new ChunkTransformer<long>(256);
+
+            var pipeline = chunk.TransformAsync(select.TransformAsync(where.TransformAsync(Sources.Range(size))));
+            await foreach (var batch in pipeline.ConfigureAwait(false))
+            {
+                total += batch.Count;
+            }
+        }
+
+        return total;
+    }
+}

--- a/samples/shadow-baseline/README.md
+++ b/samples/shadow-baseline/README.md
@@ -1,0 +1,20 @@
+# Shadow-testing golden baseline
+
+The [`Shadow Testing`](../../.github/workflows/shadow.yaml) workflow compares each nightly
+run of the [`ShadowWorkloads`](../ShadowWorkloads) samples against the BenchmarkDotNet
+reports committed **in this directory**.
+
+## Seeding / refreshing the baseline
+
+This directory ships empty on purpose — with no baseline, the nightly run is **report-only**
+(nothing to compare against, so nothing regresses). To arm the gate:
+
+1. Trigger the workflow (or take a green nightly run) and download its `shadow-results`
+   artifact.
+2. Copy the `*-report-full-compressed.json` files into this directory.
+3. Commit them. From then on the nightly run fails and files a tracking issue when a
+   workload regresses beyond threshold (default: >20% slower or >50% more allocations).
+
+Refresh the baseline deliberately whenever an intentional change shifts the numbers —
+ideally capturing it from the same CI runner class the gate runs on, since absolute
+BenchmarkDotNet numbers are environment-sensitive.


### PR DESCRIPTION
Implements #77 — production-traffic shadow testing. **Stacked on #185** (base `ci/pr-benchmarks`) to reuse `scripts/compare-benchmarks.py`.

## What

- **`samples/ShadowWorkloads`** — a BenchmarkDotNet consumer modelling realistic production traffic, each scenario doubling as runnable usage docs:
  - `VariableSizeStreamingBenchmarks` — SQL/HTTP paging with wildly variable page sizes (`Where`/`Select`/`Chunk`)
  - `ConcurrentEnumerationBenchmarks` — parallel pipelines (`Buffered`/`Where`)
  - `MixedSourceBenchmarks` — mixed sync/async enrichment (async `Select`/`SelectMany`/`Distinct`)
  - `BurstyWindowBenchmarks` — bounded take with skip/backoff + tap (`SkipWhile`/`Skip`/`Take`/`ProgressReporting`)
- **`.github/workflows/shadow.yaml`** — nightly + dispatch. Runs the workloads (`--memory`), compares against a committed golden baseline via `compare-benchmarks.py`, **opens/updates a tracking issue** and **fails** on regression beyond threshold (default >20% time / >50% alloc, configurable per run).
- **`samples/shadow-baseline/`** — golden-baseline home (ships empty → report-only until seeded; README explains seeding/refresh).
- **`docs/shadow-testing.md`** — scenarios, workflow, and how it differs from `benchmarks`/`pr-benchmarks`/`gc-profiling`.

## AC mapping

| AC | Where |
|---|---|
| Samples under `samples/` exercise public methods in realistic scenarios | `ShadowWorkloads` (4 scenarios span Where/Select/SelectMany/Distinct/Take/Skip/SkipWhile/Chunk/Buffered/ProgressReporting) |
| `shadow.yaml` nightly vs baseline, BDN results + GC stats, fails on regression | ✅ (`--memory`, `compare-benchmarks.py` gate) |
| Regressions posted as an issue; per-metric thresholds configurable | ✅ marker-dedup issue + `time_threshold`/`alloc_threshold` inputs |

The AC's "baseline release" is realized as a committed golden baseline (the sample project can't exist at an older release tag) — same pattern as the #89 GC baseline.

## Testing

All four scenarios build clean (analyzers-as-errors). One scenario was smoke-run through BDN → `-report-full-compressed.json` → `compare-benchmarks.py` locally to validate the full chain (regressed=false on self-compare). The nightly job exercises all four end to end.

Closes #77
