### PR TITLE
build: bump Abstractions 0.20 → 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped `Wolfgang.Etl.Abstractions` from 0.20.0 to 0.22.0 (adds the `ErrorPolicy`
+  property and item-error hooks on the base classes, plus simplified single-parameter
+  `ExtractorBase<T>` / `LoaderBase<T>` / `TransformerBase<TSource, TDestination>` bases).
+  Additive — no breaking changes.
+
 ### Deprecated
 
 ### Removed

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget-local" value="C:\nuget-local" />
+  </packageSources>
+</configuration>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps `Wolfgang.Etl.Abstractions` **0.20.0 → 0.22.0** on the `vNext` (0.4.0) integration branch.

## What 0.22 adds
- `ErrorPolicy` property + item-error hooks (`OnItemError`/`HandleItemError`, `CurrentErrorItemCount`) on the base classes (`ExtractorBase<,>`, `LoaderBase<,>`, `TransformerBase<,,>`).
- Simplified single-parameter bases: `ExtractorBase<T>`, `LoaderBase<T>`, `TransformerBase<TSource, TDestination>`.

## Safety
- **Zero removed members** (0.20 → 0.22 is purely additive) — no breaking changes.
- This repo references only Abstractions (no TestKit dependency), so nothing else to bump.
- `src` builds clean; the net10.0 unit suite passes (283/283) against 0.22.

## Notes
- `nuget.config` points at `C:\nuget-local` until 0.22 is published to nuget.org — CI restore will be red on hosted runners until then; drop the `nuget.config` once published (same flow as the 0.20 bump).
- Version stays **0.3.0** for now (this vNext cycle's version decided at release time).
- Foundational for follow-on stacked PRs that adopt 0.22 features.
