### PR TITLE
feat: add Tap observability pipeline operator (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Observability pipeline operator `Tap` on `IEtlPipeline<T>` (sync `Action<T>` and async
+  `Func<T, ValueTask>`): runs a side effect per item and passes the item through unchanged,
+  layered over `Through` (no core changes, no new dependencies). First of the observability
+  operator set. ([#174](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/174))
 - Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
   `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
   count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ await EtlPipeline
     .RunAsync();
 ```
 
-Available operators: `Where`, `Select`, `SelectMany` (each with sync and async overloads), `Distinct`, `DistinctBy`, `Take`, `Skip`, `TakeWhile`, `SkipWhile`, `Chunk`, `Buffered`, `Cast`, and `OfType`.
+**Data-shape operators:** `Where`, `Select`, `SelectMany` (each with sync and async overloads), `Distinct`, `DistinctBy`, `Take`, `Skip`, `TakeWhile`, `SkipWhile`, `Chunk`, `Buffered`, `Cast`, and `OfType`.
+
+**Observability operators** (watch or pace the stream without changing its shape): `Tap` (sync/async side effect per item, passed through unchanged).
 
 ---
 

--- a/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
@@ -355,6 +355,56 @@ public static class EtlPipelineOperatorExtensions
 
 
 
+    /// <summary>
+    /// Runs a synchronous side effect on each item and passes the item through unchanged — an
+    /// observability "tap" point (logging, metrics, debugging) that does not alter the stream's shape.
+    /// </summary>
+    /// <typeparam name="T">The item type. Must be non-null.</typeparam>
+    /// <param name="pipeline">The pipeline to observe.</param>
+    /// <param name="onItem">The side effect to run for each item before it flows on.</param>
+    /// <returns>A pipeline yielding the same items, in the same order, with <paramref name="onItem"/> invoked per item.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="onItem"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    ///     await EtlPipeline
+    ///         .Create()
+    ///         .From(records)
+    ///         .Tap(r =&gt; Console.WriteLine($"seen {r.Id}"))
+    ///         .To(loader)
+    ///         .RunAsync();
+    /// </code>
+    /// </example>
+    public static IEtlPipeline<T> Tap<T>(this IEtlPipeline<T> pipeline, Action<T> onItem)
+        where T : notnull
+    {
+        ThrowIfNull(pipeline, nameof(pipeline));
+        ThrowIfNull(onItem, nameof(onItem));
+
+        return pipeline.Through(new ProgressReportingTransformer<T>(onItem));
+    }
+
+
+
+    /// <summary>
+    /// Runs an asynchronous side effect on each item and passes the item through unchanged — an
+    /// observability "tap" point that does not alter the stream's shape.
+    /// </summary>
+    /// <typeparam name="T">The item type. Must be non-null.</typeparam>
+    /// <param name="pipeline">The pipeline to observe.</param>
+    /// <param name="onItem">The asynchronous side effect to run for each item before it flows on.</param>
+    /// <returns>A pipeline yielding the same items, in the same order, with <paramref name="onItem"/> awaited per item.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="onItem"/> is <see langword="null"/>.</exception>
+    public static IEtlPipeline<T> Tap<T>(this IEtlPipeline<T> pipeline, Func<T, ValueTask> onItem)
+        where T : notnull
+    {
+        ThrowIfNull(pipeline, nameof(pipeline));
+        ThrowIfNull(onItem, nameof(onItem));
+
+        return pipeline.Through(new ProgressReportingTransformer<T>(onItem));
+    }
+
+
+
     private static void ThrowIfNull(object? argument, string paramName)
     {
         if (argument is null)

--- a/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Action<T>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Func<T, System.Threading.Tasks.ValueTask>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
@@ -175,6 +175,28 @@ public class EtlPipelineOperatorExtensionsTests
     }
 
     [Fact]
+    public async Task Tap_when_sync_runs_side_effect_per_item_and_passes_items_through()
+    {
+        var seen = new List<int>();
+
+        var result = await CollectAsync(Pipe(1, 2, 3).Tap(seen.Add).AsAsyncEnumerable());
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(new[] { 1, 2, 3 }, seen);
+    }
+
+    [Fact]
+    public async Task Tap_when_async_runs_side_effect_per_item_and_passes_items_through()
+    {
+        var seen = new List<int>();
+
+        var result = await CollectAsync(Pipe(1, 2, 3).Tap(x => { seen.Add(x); return default; }).AsAsyncEnumerable());
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(new[] { 1, 2, 3 }, seen);
+    }
+
+    [Fact]
     public void Operators_when_pipeline_is_null_throw_ArgumentNullException()
     {
         IEtlPipeline<int> nullPipeline = null!;
@@ -197,6 +219,8 @@ public class EtlPipelineOperatorExtensionsTests
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Buffered(1));
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Cast<int, object>());
         Assert.Throws<ArgumentNullException>(() => nullPipeline.OfType<int, object>());
+        Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => { }));
+        Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => default));
     }
 
     [Fact]
@@ -215,5 +239,7 @@ public class EtlPipelineOperatorExtensionsTests
         Assert.Throws<ArgumentNullException>(() => pipeline.TakeWhile((Func<int, ValueTask<bool>>)null!));
         Assert.Throws<ArgumentNullException>(() => pipeline.SkipWhile((Func<int, bool>)null!));
         Assert.Throws<ArgumentNullException>(() => pipeline.SkipWhile((Func<int, ValueTask<bool>>)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.Tap((Action<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.Tap((Func<int, ValueTask>)null!));
     }
 }


### PR DESCRIPTION
First of the #174 observability operator set (stacked PRs on `vNext`): **`Tap`**.

## What
`Tap` on `IEtlPipeline<T>` — run a side effect per item and pass it through unchanged (the observability "tap" primitive):
- `Tap<T>(this IEtlPipeline<T>, Action<T> onItem)` — sync
- `Tap<T>(this IEtlPipeline<T>, Func<T, ValueTask> onItem)` — async

Layered over `Through` via the existing `ProgressReportingTransformer<T>` — **no core changes, no new package dependencies, no forced Abstractions bump** (the `Through` overload has existed since 0.16.0). `ConfigureAwait(false)` and the no-per-item-allocation guarantee come from the underlying transformer.

## #174 AC (this PR)
- [x] `Tap` (+ async) as `IEtlPipeline<T>` extensions over `Through`
- [x] Zero new dependencies; ConfigureAwait(false) throughout; no per-item allocation beyond the supplied delegate
- [x] PublicAPI.Unshipped updated (additive/MINOR, ApiCompat clean)
- [ ] `Log`, `Throttle` — follow as stacked PRs on this branch
- [ ] `Validate` — explicitly deferred pending Abstractions #84

## Testing
Build clean (Release, RS0016 + analyzers, 0 warnings). Operator tests: **23/23 pass** (added sync/async side-effect-per-item + passthrough + null-pipeline/null-delegate guards). README + CHANGELOG updated.

Part of #174.
