### PR TITLE
feat: add Log observability pipeline operator (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Func<T, ValueTask>`): runs a side effect per item and passes the item through unchanged,
   layered over `Through` (no core changes, no new dependencies). First of the observability
   operator set. ([#174](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/174))
+- Observability pipeline operator `Log` on `IEtlPipeline<T>`: `Log(format, sink)` writes one
+  formatted message per item (via a delegate sink — no `Microsoft.Extensions.Logging`
+  dependency) and passes items through unchanged. A thin wrapper over `Tap`. ([#174](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/174))
 - Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
   `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
   count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ await EtlPipeline
 
 **Data-shape operators:** `Where`, `Select`, `SelectMany` (each with sync and async overloads), `Distinct`, `DistinctBy`, `Take`, `Skip`, `TakeWhile`, `SkipWhile`, `Chunk`, `Buffered`, `Cast`, and `OfType`.
 
-**Observability operators** (watch or pace the stream without changing its shape): `Tap` (sync/async side effect per item, passed through unchanged).
+**Observability operators** (watch or pace the stream without changing its shape): `Tap` (sync/async side effect per item, passed through unchanged); `Log` (`Log(format, sink)` — one formatted message per item via a delegate sink, no logging-framework dependency).
 
 ---
 

--- a/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
@@ -405,6 +405,34 @@ public static class EtlPipelineOperatorExtensions
 
 
 
+    /// <summary>
+    /// Writes a log line per item and passes the item through unchanged — a <see cref="Tap{T}(IEtlPipeline{T}, Action{T})"/>
+    /// bound to a formatter and a sink. Deliberately dependency-free: it takes a delegate sink rather than
+    /// referencing <c>Microsoft.Extensions.Logging</c>, so bridge to an <c>ILogger</c> at the call site if desired.
+    /// </summary>
+    /// <typeparam name="T">The item type. Must be non-null.</typeparam>
+    /// <param name="pipeline">The pipeline to observe.</param>
+    /// <param name="format">Produces the log message for an item.</param>
+    /// <param name="sink">Receives each formatted message (e.g. <c>Console.WriteLine</c> or <c>msg =&gt; logger.LogInformation(msg)</c>).</param>
+    /// <returns>A pipeline yielding the same items, in the same order, logging one message per item.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/>, <paramref name="format"/>, or <paramref name="sink"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    ///     .Log(r =&gt; $"processing {r.Id}", Console.WriteLine)
+    /// </code>
+    /// </example>
+    public static IEtlPipeline<T> Log<T>(this IEtlPipeline<T> pipeline, Func<T, string> format, Action<string> sink)
+        where T : notnull
+    {
+        ThrowIfNull(pipeline, nameof(pipeline));
+        ThrowIfNull(format, nameof(format));
+        ThrowIfNull(sink, nameof(sink));
+
+        return pipeline.Tap(item => sink(format(item)));
+    }
+
+
+
     private static void ThrowIfNull(object? argument, string paramName)
     {
         if (argument is null)

--- a/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Log<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Func<T, string!>! format, System.Action<string!>! sink) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Action<T>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Func<T, System.Threading.Tasks.ValueTask>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
@@ -197,6 +197,17 @@ public class EtlPipelineOperatorExtensionsTests
     }
 
     [Fact]
+    public async Task Log_writes_a_formatted_message_per_item_and_passes_items_through()
+    {
+        var lines = new List<string>();
+
+        var result = await CollectAsync(Pipe(1, 2, 3).Log(x => $"item {x}", lines.Add).AsAsyncEnumerable());
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(new[] { "item 1", "item 2", "item 3" }, lines);
+    }
+
+    [Fact]
     public void Operators_when_pipeline_is_null_throw_ArgumentNullException()
     {
         IEtlPipeline<int> nullPipeline = null!;
@@ -221,6 +232,7 @@ public class EtlPipelineOperatorExtensionsTests
         Assert.Throws<ArgumentNullException>(() => nullPipeline.OfType<int, object>());
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => { }));
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => default));
+        Assert.Throws<ArgumentNullException>(() => nullPipeline.Log(x => x.ToString(), _ => { }));
     }
 
     [Fact]
@@ -241,5 +253,7 @@ public class EtlPipelineOperatorExtensionsTests
         Assert.Throws<ArgumentNullException>(() => pipeline.SkipWhile((Func<int, ValueTask<bool>>)null!));
         Assert.Throws<ArgumentNullException>(() => pipeline.Tap((Action<int>)null!));
         Assert.Throws<ArgumentNullException>(() => pipeline.Tap((Func<int, ValueTask>)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.Log(null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() => pipeline.Log(x => x.ToString(), null!));
     }
 }


### PR DESCRIPTION
Second of the #174 observability operator set. **Stacked on #199** (base `feature/tap-operator`).

## What
`Log<T>(this IEtlPipeline<T>, Func<T,string> format, Action<string> sink)` — writes one formatted message per item and passes items through unchanged. A thin wrapper over `Tap`.

**Dependency-free by design:** takes a delegate sink (e.g. `Console.WriteLine`, or `msg => logger.LogInformation(msg)`) rather than referencing `Microsoft.Extensions.Logging` — bridge to `ILogger` at the call site. Param order is `format` (most significant) then `sink` (output target) last.

## Testing
Build clean (RS0016 + analyzers, 0 warnings); operator tests **24/24** (added per-item formatted-output + passthrough + null-pipeline/format/sink guards). README + CHANGELOG updated.

Part of #174. Next: `Throttle` (stacked on this).
