### PR TITLE
feat: add Throttle observability pipeline operator (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Observability pipeline operator `Log` on `IEtlPipeline<T>`: `Log(format, sink)` writes one
   formatted message per item (via a delegate sink — no `Microsoft.Extensions.Logging`
   dependency) and passes items through unchanged. A thin wrapper over `Tap`. ([#174](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/174))
+- Observability pipeline operator `Throttle` on `IEtlPipeline<T>` + `ThrottleTransformer<T>`:
+  paces successive items at least a minimum `TimeSpan` apart (adaptive — a slow consumer isn't
+  delayed further; first item not delayed; honours the cancellation token) for rate-limiting a
+  downstream sink. ([#174](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/174))
 - Property-based fuzzing: a CsCheck suite asserts each transformer is equivalent to its
   `System.Linq` counterpart on randomised input, plus a scheduled `fuzz.yaml` (high iteration
   count, uploads results and auto-files an issue on failure). ([#76](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/76))

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ await foreach (var row in projected.TransformAsync(filtered.TransformAsync(buffe
 | `PassThroughTransformer<T>` | Identity pass-through; also implements `ITransformWithCancellationAsync<T, T>` |
 | `BufferedTransformer<T>` | Decouples producer from consumer via a `System.Threading.Channels` buffer |
 | `ProgressReportingTransformer<T>` | Calls a sync or async callback per item without altering the stream |
+| `ThrottleTransformer<T>` | Paces items at least a minimum `TimeSpan` apart (adaptive; honours cancellation) without altering the stream |
 
 ### Composition
 
@@ -107,7 +108,7 @@ await EtlPipeline
 
 **Data-shape operators:** `Where`, `Select`, `SelectMany` (each with sync and async overloads), `Distinct`, `DistinctBy`, `Take`, `Skip`, `TakeWhile`, `SkipWhile`, `Chunk`, `Buffered`, `Cast`, and `OfType`.
 
-**Observability operators** (watch or pace the stream without changing its shape): `Tap` (sync/async side effect per item, passed through unchanged); `Log` (`Log(format, sink)` — one formatted message per item via a delegate sink, no logging-framework dependency).
+**Observability operators** (watch or pace the stream without changing its shape): `Tap` (sync/async side effect per item, passed through unchanged); `Log` (`Log(format, sink)` — one formatted message per item via a delegate sink, no logging-framework dependency); `Throttle` (`Throttle(minInterval)` — paces items at least a `TimeSpan` apart to rate-limit a downstream sink).
 
 ---
 

--- a/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
+++ b/src/Wolfgang.Etl.Transformers/EtlPipelineOperatorExtensions.cs
@@ -433,6 +433,33 @@ public static class EtlPipelineOperatorExtensions
 
 
 
+    /// <summary>
+    /// Paces the pipeline so successive items are yielded at least <paramref name="minInterval"/> apart,
+    /// without changing the stream's shape or order — rate-limiting for a downstream sink that must not be
+    /// hit too fast. The first item is not delayed; pacing is adaptive (a consumer that was already slow is
+    /// not delayed further) and observes the pipeline's cancellation token.
+    /// </summary>
+    /// <typeparam name="T">The item type. Must be non-null.</typeparam>
+    /// <param name="pipeline">The pipeline to pace.</param>
+    /// <param name="minInterval">The minimum time between successive items. <see cref="TimeSpan.Zero"/> is a pass-through.</param>
+    /// <returns>A pipeline yielding the same items, in the same order, paced apart.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="minInterval"/> is negative.</exception>
+    /// <example>
+    /// <code>
+    ///     .Throttle(TimeSpan.FromMilliseconds(200))   // at most ~5 items/second
+    /// </code>
+    /// </example>
+    public static IEtlPipeline<T> Throttle<T>(this IEtlPipeline<T> pipeline, TimeSpan minInterval)
+        where T : notnull
+    {
+        ThrowIfNull(pipeline, nameof(pipeline));
+
+        return pipeline.Through(new ThrottleTransformer<T>(minInterval));
+    }
+
+
+
     private static void ThrowIfNull(object? argument, string paramName)
     {
         if (argument is null)

--- a/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Transformers/PublicAPI.Unshipped.txt
@@ -2,3 +2,7 @@
 static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Log<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Func<T, string!>! format, System.Action<string!>! sink) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Action<T>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Tap<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Func<T, System.Threading.Tasks.ValueTask>! onItem) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Transformers.EtlPipelineOperatorExtensions.Throttle<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.TimeSpan minInterval) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+Wolfgang.Etl.Transformers.ThrottleTransformer<T>
+Wolfgang.Etl.Transformers.ThrottleTransformer<T>.ThrottleTransformer(System.TimeSpan minInterval) -> void
+Wolfgang.Etl.Transformers.ThrottleTransformer<T>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<T>! items) -> System.Collections.Generic.IAsyncEnumerable<T>!

--- a/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+
+
+namespace Wolfgang.Etl.Transformers;
+
+/// <summary>
+/// Paces an asynchronous sequence so that successive items are yielded no closer together than a
+/// minimum interval, without changing the stream's shape or order. Useful for rate-limiting a
+/// downstream sink (an API, a database) that must not be hit too fast.
+/// </summary>
+/// <typeparam name="T">The type of items flowing through the transformer. Must be non-null.</typeparam>
+/// <remarks>
+/// <para>
+/// The pacing is <b>adaptive</b>: the delay before an item is the remaining time until the minimum
+/// interval since the previous item has elapsed, so a consumer that was already slow is not delayed
+/// further. The first item is never delayed. All waits observe the enumeration's
+/// <see cref="CancellationToken"/> (supply it via <c>.WithCancellation(token)</c>).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+///     var throttle = new ThrottleTransformer&lt;Request&gt;(TimeSpan.FromMilliseconds(200));
+///     await foreach (var request in throttle.TransformAsync(source))
+///     {
+///         // at most ~5 items/second
+///     }
+/// </code>
+/// </example>
+public sealed class ThrottleTransformer<T> : ITransformAsync<T, T>
+    where T : notnull
+{
+    private readonly TimeSpan _minInterval;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private readonly Func<long> _getTimestamp;
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThrottleTransformer{T}"/> class.
+    /// </summary>
+    /// <param name="minInterval">
+    /// The minimum time between successive yielded items. <see cref="TimeSpan.Zero"/> disables pacing
+    /// (a pass-through).
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="minInterval"/> is negative.</exception>
+    public ThrottleTransformer(TimeSpan minInterval)
+        : this(minInterval, static (delay, token) => Task.Delay(delay, token), Stopwatch.GetTimestamp)
+    {
+    }
+
+
+    // Test seam: inject a delay and a monotonic timestamp source so pacing can be verified
+    // deterministically without real time passing.
+    internal ThrottleTransformer(TimeSpan minInterval, Func<TimeSpan, CancellationToken, Task> delayAsync, Func<long> getTimestamp)
+    {
+        if (minInterval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minInterval), minInterval, "The minimum interval must not be negative.");
+        }
+
+        _minInterval = minInterval;
+        _delayAsync = delayAsync;
+        _getTimestamp = getTimestamp;
+    }
+
+
+    /// <summary>
+    /// Asynchronously yields each item from <paramref name="items"/> in order, pacing successive items
+    /// to at least the configured minimum interval apart.
+    /// </summary>
+    /// <param name="items">The asynchronous source sequence.</param>
+    /// <returns>An asynchronous sequence with the same items, in the same order, paced apart.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(items);
+#else
+#pragma warning disable RCS1140
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+#pragma warning restore RCS1140
+#endif
+        return TransformAsyncCore(items);
+    }
+
+
+    private async IAsyncEnumerable<T> TransformAsyncCore
+    (
+        IAsyncEnumerable<T> items,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        var hasPrevious = false;
+        long previousTimestamp = 0;
+
+        await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))
+        {
+            if (hasPrevious && _minInterval > TimeSpan.Zero)
+            {
+                var elapsed = TimeSpan.FromSeconds((_getTimestamp() - previousTimestamp) / (double)Stopwatch.Frequency);
+                var wait = _minInterval - elapsed;
+                if (wait > TimeSpan.Zero)
+                {
+                    await _delayAsync(wait, token).ConfigureAwait(continueOnCapturedContext: false);
+                }
+            }
+
+            yield return item;
+
+            hasPrevious = true;
+            previousTimestamp = _getTimestamp();
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
@@ -65,8 +65,8 @@ public sealed class ThrottleTransformer<T> : ITransformAsync<T, T>
         }
 
         _minInterval = minInterval;
-        _delayAsync = delayAsync;
-        _getTimestamp = getTimestamp;
+        _delayAsync = delayAsync ?? throw new ArgumentNullException(nameof(delayAsync));
+        _getTimestamp = getTimestamp ?? throw new ArgumentNullException(nameof(getTimestamp));
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/EtlPipelineOperatorExtensionsTests.cs
@@ -208,6 +208,18 @@ public class EtlPipelineOperatorExtensionsTests
     }
 
     [Fact]
+    public async Task Throttle_yields_all_items_in_order()
+    {
+        var result = await CollectAsync(Pipe(1, 2, 3).Throttle(TimeSpan.FromMilliseconds(1)).AsAsyncEnumerable());
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+    [Fact]
+    public void Throttle_when_min_interval_is_negative_throws_ArgumentOutOfRangeException()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Pipe(1, 2, 3).Throttle(TimeSpan.FromMilliseconds(-1)));
+
+    [Fact]
     public void Operators_when_pipeline_is_null_throw_ArgumentNullException()
     {
         IEtlPipeline<int> nullPipeline = null!;
@@ -233,6 +245,7 @@ public class EtlPipelineOperatorExtensionsTests
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => { }));
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Tap(_ => default));
         Assert.Throws<ArgumentNullException>(() => nullPipeline.Log(x => x.ToString(), _ => { }));
+        Assert.Throws<ArgumentNullException>(() => nullPipeline.Throttle(TimeSpan.Zero));
     }
 
     [Fact]

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -37,6 +38,34 @@ public class ThrottleTransformerTests
         Assert.Equal(new[] { 1, 2, 3 }, result);
         Assert.Equal(2, waits.Count);          // the first item is never delayed
         Assert.All(waits, w => Assert.Equal(interval, w));
+    }
+
+
+    [Fact]
+    public async Task TransformAsync_when_consumer_is_already_slower_than_the_interval_adds_no_delay()
+    {
+        var waits = new List<TimeSpan>();
+        long clock = 0;
+        // Advance a full second per timestamp read — always >= the 250 ms interval, so the measured
+        // elapsed already exceeds it and no additional wait should be requested (the adaptive path).
+        var step = Stopwatch.Frequency;
+        var sut = new ThrottleTransformer<int>(
+            TimeSpan.FromMilliseconds(250),
+            (delay, _) => { waits.Add(delay); return Task.CompletedTask; },
+            () => { clock += step; return clock; });
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Empty(waits);
+    }
+
+
+    [Fact]
+    public void Internal_ctor_when_delay_or_timestamp_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ThrottleTransformer<int>(TimeSpan.Zero, null!, () => 0L));
+        Assert.Throws<ArgumentNullException>(() => new ThrottleTransformer<int>(TimeSpan.Zero, (_, _) => Task.CompletedTask, null!));
     }
 
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Wolfgang.Etl.Transformers.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Etl.Transformers.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="ThrottleTransformer{T}"/> pacing deterministically via its internal test seam
+/// (an injected delay recorder and a fixed timestamp source), so no real time passes.
+/// </summary>
+public class ThrottleTransformerTests
+{
+    [Fact]
+    public async Task TransformAsync_yields_all_items_in_order()
+    {
+        var sut = new ThrottleTransformer<int>(TimeSpan.FromMilliseconds(1));
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+    [Fact]
+    public async Task TransformAsync_delays_each_item_after_the_first_by_the_min_interval()
+    {
+        var waits = new List<TimeSpan>();
+        var interval = TimeSpan.FromMilliseconds(250);
+        // Fixed timestamp => measured elapsed is always 0 => a full-interval wait is requested each time.
+        var sut = new ThrottleTransformer<int>(interval, (delay, _) => { waits.Add(delay); return Task.CompletedTask; }, () => 0L);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(2, waits.Count);          // the first item is never delayed
+        Assert.All(waits, w => Assert.Equal(interval, w));
+    }
+
+
+    [Fact]
+    public async Task TransformAsync_when_min_interval_is_zero_never_delays()
+    {
+        var waits = new List<TimeSpan>();
+        var sut = new ThrottleTransformer<int>(TimeSpan.Zero, (delay, _) => { waits.Add(delay); return Task.CompletedTask; }, () => 0L);
+
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { 1, 2, 3 })));
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Empty(waits);
+    }
+
+
+    [Fact]
+    public void Ctor_when_min_interval_is_negative_throws_ArgumentOutOfRangeException()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new ThrottleTransformer<int>(TimeSpan.FromMilliseconds(-1)));
+
+
+    [Fact]
+    public void TransformAsync_when_items_is_null_throws_ArgumentNullException()
+        => Assert.Throws<ArgumentNullException>(() => new ThrottleTransformer<int>(TimeSpan.Zero).TransformAsync(null!));
+}


### PR DESCRIPTION
Third and final of the #174 observability operator set. **Stacked on #200** (base `feature/log-operator`).

## What
- **`ThrottleTransformer<T>`** — new transformer that paces successive items at least `minInterval` apart. **Adaptive** (delay = remaining time to the interval since the previous item, so a slow consumer isn't delayed further), first item never delayed, all waits honour the `CancellationToken`. `TimeSpan.Zero` = pass-through; negative → `ArgumentOutOfRangeException`.
- **`Throttle<T>(this IEtlPipeline<T>, TimeSpan minInterval)`** — operator layered over `Through`.

Multi-TFM, `ConfigureAwait(false)` throughout, no new dependencies, no Abstractions bump. The transformer has an **internal clock/delay seam** (injected delay recorder + timestamp source) so pacing is verified **deterministically without real time passing**.

## #174 — set complete
- [x] `Tap` (#199), `Log` (#200), `Throttle` (this) as `IEtlPipeline<T>` extensions over `Through`
- [x] Zero new deps; ConfigureAwait(false); no per-item allocation beyond the delegate
- [x] PublicAPI.Unshipped updated; additive/MINOR (ApiCompat clean)
- [x] `Validate` explicitly deferred pending Abstractions #84

## Testing
Build clean (Release, RS0016 + analyzers, 0 warnings). **31/31** unit tests pass (new `ThrottleTransformerTests`: deterministic paced-delay via fake clock, zero-interval no-op, negative-arg + null guards; plus operator passthrough + guards). README + CHANGELOG updated.

Closes #174.
