### PR TITLE
ci(sourcelink-stepinto): pin netcoredbg download by SHA-256 (#198)

### DIFF
--- a/.github/workflows/sourcelink-stepinto.yaml
+++ b/.github/workflows/sourcelink-stepinto.yaml
@@ -36,6 +36,10 @@ concurrency:
 
 env:
   NETCOREDBG_VERSION: 3.1.2-1054
+  # SHA-256 of netcoredbg-linux-amd64.tar.gz for the pinned version. Verified before extraction
+  # so a replaced/compromised release asset can't execute arbitrary code in CI (#198). Update
+  # this whenever NETCOREDBG_VERSION changes.
+  NETCOREDBG_SHA256: 4f58ae90aacbccdf85dc7d6a0d8893796dd3750d6867fe31396a6b7bee09c9cb
   # Reduce tiered-JIT reordering so the step-into target stays stable.
   DOTNET_TieredCompilation: '0'
 
@@ -82,6 +86,7 @@ jobs:
         run: |
           url="https://github.com/Samsung/netcoredbg/releases/download/${NETCOREDBG_VERSION}/netcoredbg-linux-amd64.tar.gz"
           curl -sSfL "$url" -o netcoredbg.tar.gz
+          echo "${NETCOREDBG_SHA256}  netcoredbg.tar.gz" | sha256sum -c -
           tar -xzf netcoredbg.tar.gz
           echo "NETCOREDBG=$PWD/netcoredbg/netcoredbg" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Closes #198 (the deferred hardening item from the 0.3.0 review).

## What
`sourcelink-stepinto.yaml` downloads and executes `netcoredbg` from a GitHub release. This pins that asset by **SHA-256** and verifies it (`sha256sum -c`) **before** extracting/executing, so a replaced/compromised release asset can't run arbitrary code in CI.

- Added `NETCOREDBG_SHA256: 4f58ae90…09c9cb` next to `NETCOREDBG_VERSION: 3.1.2-1054` (digest computed from the pinned asset).
- Install step now runs `echo "${NETCOREDBG_SHA256}  netcoredbg.tar.gz" | sha256sum -c -` before `tar -xzf`.
- Comment notes to update both together on a version bump.

Base `main` (that's where the workflow lives — it came in with the 0.3.0 workflows). Protected workflow file → **admin-bypass** for the `Detect .NET Projects` guard. YAML validated locally.
