### PR TITLE
chore: bump PackageValidation baseline 0.3.0 → 0.4.0

### DIFF
--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -33,7 +33,7 @@
       CompatibilitySuppressions.xml so they don't recur silently.
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.3.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Routine post-release maintenance: 0.4.0 is live on NuGet, so bump `PackageValidationBaselineVersion` to 0.4.0 so the next release's ABI/compat gate validates against the 0.4.0 public surface. Csproj-only, non-protected — normal CI.