### PR TITLE
Release 0.5.0 — adopt ETL core 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.5.0] - 2026-08-13
+
+### Changed
+
+- Adopted **ETL core 0.22.0** — `Wolfgang.Etl.Abstractions` 0.20.0 -> 0.22.0, along with the
+  test-only `Wolfgang.Etl.TestKit` / `Wolfgang.Etl.TestKit.Xunit` references. 0.22.0 is the release in
+  which the TestKit packages were folded into the ETL-Abstractions repository and now build and ship
+  from there. The public API of all four core packages is unchanged.
+- Inherited from Abstractions 0.22.0: the `await foreach` sites in `ExtractorBase` and
+  `TransformerBase` now use `ConfigureAwait(false)`, removing a sync-over-async deadlock risk for
+  consumers on the `net462` and `netstandard2.0` targets that drive the pipeline from a
+  synchronization context. No behavioural change on the modern targets.
+
 ## [0.4.0] - 2026-08-09
 
 ### Added

--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Bump ETL core packages to 0.22.0

Adopts [ETL-Abstractions#357](https://github.com/Chris-Wolfgang/ETL-Abstractions/pull/357), which folds `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` into the Abstractions repo. All four packages are now lockstep-versioned at **0.22.0**.

### Why this is a pure version bump
The `PublicAPI.Shipped.txt` surface of all four packages is **byte-identical** between the versions this repo referenced and 0.22.0 (verified line-by-line: 0 added, 0 removed). The fold was a structural change to how the packages are built and released, not to what they expose. No source changes are required here.

### Verification
Run locally against the 0.22.0 packages from a local feed:
- `dotnet build -c Release` — clean
- `dotnet test -f net10.0` — full suite green

### ⚠️ CI will be red until 0.22.0 publishes
`Wolfgang.Etl.*` 0.22.0 is **not yet on nuget.org** — it only exists in a local feed pending the ETL-Abstractions 0.22.0 release. CI restore will fail with NU1102 until that release ships. **Do not merge before ETL-Abstractions 0.22.0 is published.**
