### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.5.0] - 2026-08-13
+
+### Changed
+
+- Adopted **ETL core 0.22.0** — `Wolfgang.Etl.Abstractions` 0.20.0 -> 0.22.0, along with the
+  test-only `Wolfgang.Etl.TestKit` / `Wolfgang.Etl.TestKit.Xunit` references. 0.22.0 is the release in
+  which the TestKit packages were folded into the ETL-Abstractions repository and now build and ship
+  from there. The public API of all four core packages is unchanged.
+- Inherited from Abstractions 0.22.0: the `await foreach` sites in `ExtractorBase` and
+  `TransformerBase` now use `ConfigureAwait(false)`, removing a sync-over-async deadlock risk for
+  consumers on the `net462` and `netstandard2.0` targets that drive the pipeline from a
+  synchronization context. No behavioural change on the modern targets.
+
 ## [0.4.0] - 2026-08-09
 
 ### Added

--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Release PR: promotes the version bump and the ETL core 0.22.0 uptake from `vNext` to `main`.

## Why this is needed

`release.yaml` builds from the **tag commit**, and its first job validates that the tag version matches a `<Version>` in a `src/` csproj. The version bump landed on `vNext`, so tagging `main` before this merge produced:

```
Release tag 'vX.Y.0' (version 'X.Y.0') does not match any src csproj version. Found: <old>.
```

Nothing was published — `Validate Release Build` fails first and every downstream job (pack, publish, attest) skips. So NuGet is untouched and the version number is still free.

## Order that works

1. Merge this PR (`vNext` -> `main`).
2. Delete the failed Release **and** its tag — the tag currently points at a `main` commit that predates the version bump.
3. Re-create the tag on the new `main` tip and publish the Release; `release.yaml` then validates and publishes.

Re-running the failed workflow without step 2 will not help: the tag object still points at the old commit.
