### PR TITLE
chore(build): gate PublicApiAnalyzer PackageReference on Exists('PublicAPI.Shipped.txt') (#208)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,13 +67,20 @@
 
   <ItemGroup>
     <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
-         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
-         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
-         project directory and the analyzer activates for that project only.
-         Library projects under src/ should opt in; test / example /
-         benchmark projects should not. Per-repo enablement is tracked as a
-         follow-up maintenance issue. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
+         detection. Opt-in PER PROJECT via Exists(): drop PublicAPI.Shipped.txt +
+         PublicAPI.Unshipped.txt into a src project directory and the analyzer
+         activates for that project only. Library projects under src/ should opt
+         in; test / example / benchmark projects should not.
+
+         Both the PackageReference AND the AdditionalFiles are gated on the same
+         Exists() check. MSBuild honors the Condition on AdditionalFiles, so
+         gating just those was enough for the compiler-driven build. InspectCode
+         doesn't honor the Condition on AdditionalFiles — it loads the analyzer
+         via the PackageReference and then flags RS0016/RS0037 on every public
+         API because it can't find the tracking file. Gating the PackageReference
+         itself removes the analyzer entirely from non-src projects, which is
+         the correct behavior everywhere. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" Condition="Exists('PublicAPI.Shipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
**Protected-file PR** split out of #212 per the fleet's protected-file-pr-split convention. Contains only the `Directory.Build.props` change — which will trip the `Detect .NET Projects` guard and skip Stage 1/2/3 tests — so this PR needs an **admin bypass** merge. The other 26 non-protected files land in #212, which will pass CI normally once this merges.

## Change
Adds `Condition="Exists('PublicAPI.Shipped.txt')"` to the `Microsoft.CodeAnalysis.PublicApiAnalyzers` PackageReference itself (not just the AdditionalFiles below), so the analyzer never loads in test / benchmark / sample / profiling projects.

## Why
MSBuild honored the pre-existing Condition on the `AdditionalFiles`, so the compiler-driven build was clean. **InspectCode doesn't honor that Condition** — it loads the analyzer via the PackageReference and then flags every public API because the tracking files aren't wired up. That produced **~664/706 open code-scanning alerts** in this repo, all RS0016 / RS0037.

Gating the PackageReference itself removes the analyzer entirely from non-src projects, which is the correct behavior everywhere. Recorded as a fleet-wide follow-up in `reference_inspectcode_publicapi_false_positives`.

## Test plan
* Manual: build succeeds locally with the change (verified — no errors, only pre-existing MultipleGlobalAnalyzerKeys warnings from the worktree living inside the parent repo)
* After merge, #212 rebases onto main and full CI passes there

Refs #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)