### PR TITLE
test: eliminate empty test-POCO classes and hoist S2190 pragma to method level (#208)

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/BufferedTransformerTests.cs
@@ -126,11 +126,11 @@ public class BufferedTransformerTests
     [Fact]
     public async Task TransformAsync_preserves_reference_identity_of_yielded_items()
     {
-        var a = new Box();
-        var b = new Box();
-        var c = new Box();
+        var a = new object();
+        var b = new object();
+        var c = new object();
 
-        var sut = new BufferedTransformer<Box>(capacity: 8);
+        var sut = new BufferedTransformer<object>(capacity: 8);
         var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b, c })));
 
         Assert.Collection
@@ -354,26 +354,22 @@ public class BufferedTransformerTests
     /// when its iterator is disposed - used to verify the BufferedTransformer cleans up the
     /// upstream when the consumer abandons or cancels.
     /// </summary>
+#pragma warning disable S2190 // deliberate: infinite source; termination comes from consumer disposal / cancellation, verified via disposalSignal
     private static async IAsyncEnumerable<int> InfiniteSource(TaskCompletionSource<bool> disposalSignal)
     {
         var i = 0;
         try
         {
-#pragma warning disable S2190 // deliberate: infinite source; termination comes from consumer disposal / cancellation, verified via disposalSignal
             while (true)
             {
                 await Task.Yield();
                 yield return i++;
             }
-#pragma warning restore S2190
         }
         finally
         {
             disposalSignal.TrySetResult(true);
         }
     }
-
-
-
-    private sealed class Box;
+#pragma warning restore S2190
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/CastTransformerTests.cs
@@ -64,9 +64,9 @@ public class CastTransformerTests
     {
         var rex = new Dog();
         var buddy = new Dog();
-        var sut = new CastTransformer<Animal, Dog>();
+        var sut = new CastTransformer<IAnimal, Dog>();
 
-        var result = await CollectAsync(sut.TransformAsync(ToAsync(new Animal[] { rex, buddy })));
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new IAnimal[] { rex, buddy })));
 
         Assert.Same(rex, result[0]);
         Assert.Same(buddy, result[1]);
@@ -118,8 +118,8 @@ public class CastTransformerTests
     [Fact]
     public async Task TransformAsync_when_subtype_downcast_encounters_wrong_subtype_throws()
     {
-        var sut = new CastTransformer<Animal, Dog>();
-        var source = new Animal[] { new Dog(), new Cat() };
+        var sut = new CastTransformer<IAnimal, Dog>();
+        var source = new IAnimal[] { new Dog(), new Cat() };
 
         await Assert.ThrowsAsync<InvalidCastException>
         (
@@ -136,9 +136,9 @@ public class CastTransformerTests
     {
         var rex = new Dog();
         var buddy = new Dog();
-        var sut = new CastTransformer<Animal, Dog>();
+        var sut = new CastTransformer<IAnimal, Dog>();
 
-        var result = await CollectAsync(sut.TransformAsync(ToAsync(new Animal[] { rex, buddy })));
+        var result = await CollectAsync(sut.TransformAsync(ToAsync(new IAnimal[] { rex, buddy })));
 
         Assert.Collection
         (
@@ -194,13 +194,17 @@ public class CastTransformerTests
 
     // test fixtures
 
-    private abstract class Animal;
+    // Marker interface + two implementing sealed classes model a small polymorphic
+    // hierarchy for the subtype-downcast tests above. Using an interface (rather than
+    // an empty abstract class) sidesteps S2094 "empty class" without pulling in any
+    // real behavior the tests would otherwise have to ignore.
+    private interface IAnimal;
 
 
 
-    private sealed class Dog : Animal;
+    private sealed class Dog : IAnimal;
 
 
 
-    private sealed class Cat : Animal;
+    private sealed class Cat : IAnimal;
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ChunkTransformerTests.cs
@@ -228,11 +228,11 @@ public class ChunkTransformerTests
     [Fact]
     public async Task TransformAsync_preserves_reference_identity_of_items_within_chunks()
     {
-        var a = new Box();
-        var b = new Box();
-        var c = new Box();
+        var a = new object();
+        var b = new object();
+        var c = new object();
 
-        var sut = new ChunkTransformer<Box>(size: 2);
+        var sut = new ChunkTransformer<object>(size: 2);
         var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b, c })));
 
         Assert.Same(a, result[0][0]);
@@ -347,5 +347,4 @@ public class ChunkTransformerTests
 
 
 
-    private sealed class Box;
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/PassThroughTransformerTests.cs
@@ -41,10 +41,10 @@ public class PassThroughTransformerTests
     [Fact]
     public async Task TransformAsync_preserves_reference_identity_for_each_item()
     {
-        var item1 = new Box();
-        var item2 = new Box();
+        var item1 = new object();
+        var item2 = new object();
         var source = new[] { item1, item2 };
-        var sut = new PassThroughTransformer<Box>();
+        var sut = new PassThroughTransformer<object>();
 
         var result = await CollectAsync(sut.TransformAsync(ToAsync(source)));
 
@@ -193,18 +193,16 @@ public class PassThroughTransformerTests
     // ---------- helpers ----------
 
     // ReSharper disable once IteratorNeverReturns — deliberate infinite source. Test fixtures pair this with a Take/cancellation to bound consumption; the never-returning shape IS the scenario under test.
+#pragma warning disable S2190 // deliberate: same rationale as the R# comment above; consumer-terminated
     private static IEnumerable<int> InfiniteSource()
     {
         var i = 0;
-#pragma warning disable S2190 // deliberate: see comment above
         while (true)
         {
             yield return i++;
         }
-#pragma warning restore S2190
     }
+#pragma warning restore S2190
 
 
-
-    private sealed class Box;
 }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ProgressReportingTransformerTests.cs
@@ -240,10 +240,10 @@ public class ProgressReportingTransformerTests
     [Fact]
     public async Task TransformAsync_preserves_reference_identity_of_yielded_items()
     {
-        var a = new Box();
-        var b = new Box();
+        var a = new object();
+        var b = new object();
 
-        var sut = new ProgressReportingTransformer<Box>(_ => { });
+        var sut = new ProgressReportingTransformer<object>(_ => { });
 
         var result = await CollectAsync(sut.TransformAsync(ToAsync(new[] { a, b })));
 
@@ -289,5 +289,4 @@ public class ProgressReportingTransformerTests
 
 
 
-    private sealed class Box;
 }


### PR DESCRIPTION
## Summary
Follow-up to #212. The post-merge InspectCode scan on main surfaced 7 alerts that survived because of narrow choices in that PR:

* **S2094 (5×)** — the `private sealed class Box;` placeholders in BufferedTransformerTests, ChunkTransformerTests, PassThroughTransformerTests, and ProgressReportingTransformerTests are literal empty classes. Reference-identity tests only need distinct instances, so swap the fixture type to `object` (`new object()` + `TransformerT<object>`) and delete the empty class entirely.
* **S2094 on CastTransformerTests.Animal** — rework `Animal` from an empty abstract class into an empty **marker interface** `IAnimal`. S2094 doesn't fire on interfaces, and the subtype-downcast tests still get a polymorphic hierarchy (Dog / Cat implement IAnimal instead of inheriting Animal).
* **S2190 (2×) on the two `InfiniteSource` iterators** — the pragma in #212 wrapped `while (true)` inside the method, but S2190 fires at the method declaration line. Move `#pragma warning disable S2190` outside each method so the suppression covers the actual warning site.

## Test plan
* Verified locally: 320/320 unit tests pass on net10.0.
* After merge, `gh api ".../code-scanning/alerts?state=open&tool_name=InspectCode" --jq 'length'` should return 0.

Refs #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)