### PR TITLE
chore(release): advance PackageValidation baseline to 0.5.0

### DIFF
--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -33,7 +33,7 @@
       CompatibilitySuppressions.xml so they don't recur silently.
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Post-release chore following the 0.5.0 release.

`PackageValidationBaselineVersion` tracks the **last published** version and is deliberately left alone during release prep — advancing it early would validate the package against itself and silently disable the ABI gate for that release.

0.5.0 is now live on nuget.org, so it becomes the baseline for the next release. Left at 0.4.0, the next release would have been validated against a two-versions-back baseline, weakening the gate without failing anything visibly.

## Verification

`dotnet pack -c Release` succeeds with PackageValidation green against the new 0.5.0 baseline — no CP-series errors. That is the meaningful check, since PackageValidation downloads the published 0.5.0 package from nuget.org and compares the built assembly against it.

One line changed.