### PR TITLE
docs(changelog): note the PublicApiAnalyzer gate that landed for #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Code-scanning noise floor** ([#208](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/208)):
+  gated the `Microsoft.CodeAnalysis.PublicApiAnalyzers` PackageReference on
+  `Exists('PublicAPI.Shipped.txt')` in `Directory.Build.props` so it no longer loads in
+  test / benchmark / sample / profiling projects. This eliminates ~664 recurring
+  RS0016/RS0037 alerts from InspectCode against non-src projects that don't declare a
+  public API surface. No consumer-visible change.
+
 ## [0.5.0] - 2026-08-13
 
 ### Changed


### PR DESCRIPTION
## Summary
Adds a CHANGELOG entry under Unreleased/Security documenting the ~664-alert reduction from the #208 code-scanning cleanup so consumers browsing the changelog see the maintenance work.

Also re-triggers \`pr.yaml\` (and therefore InspectCode) on main, which auto-closes 7 stale main-branch alerts that were actually fixed in #214 but never re-scanned — \`pr.yaml\` only fires on \`pull_request_target\`, so nothing has scanned main since #214 merged.

## Test plan
* After merge, \`gh api ".../code-scanning/alerts?state=open&tool_name=InspectCode" --jq 'length'\` returns **0**.

Refs #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)