### PR TITLE
fix(examples): mark examples/* non-packable to stop stray nupkg emit (#216)

### DIFF
--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -8,5 +8,13 @@
   -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);MA0048;S3903;CA2007</NoWarn>
+
+    <!--
+      Examples are demonstrations, not shippable packages. Without this,
+      solution-scope `dotnet pack` emits stray .nupkg files under each
+      examples/*/bin/Release/, which release / attest jobs that glob
+      **/*.nupkg would treat as real artifacts (issue #216).
+    -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adds \`<IsPackable>false</IsPackable>\` to \`examples/Directory.Build.props\` so every example project (BasicChain, LinqOps, BufferedPipeline, plus any future one) inherits it without needing an edit.

**Before:** \`dotnet pack -c Release\` at solution scope emitted \`BasicChain.1.0.0.nupkg\`, \`LinqOps.1.0.0.nupkg\`, and \`BufferedPipeline.1.0.0.nupkg\` alongside the real \`Wolfgang.Etl.Transformers.0.5.0.nupkg\` — a release / attest job that globs \`**/*.nupkg\` would pick those up.

**After:** verified locally — exactly one \`.nupkg\` (+ \`.snupkg\`) is emitted, for \`Wolfgang.Etl.Transformers\`.

Closes #216.

## Test plan
- [x] \`dotnet pack -c Release\` at solution scope produces exactly one \`.nupkg\` (plus its \`.snupkg\`) for \`Wolfgang.Etl.Transformers\`.
- [x] Any newly added \`examples/*\` project inherits \`IsPackable=false\` from \`examples/Directory.Build.props\` — no per-project edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)