### PR TITLE
fix(tests): add coverlet.collector to the 5 test projects missing it (#217)

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
@@ -25,6 +25,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
@@ -36,6 +36,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
@@ -25,6 +25,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
@@ -28,6 +28,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
@@ -29,6 +29,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
The \`Coverage Report\` workflow has failed on every run — including release tags — because \`Wolfgang.Etl.Transformers.Tests.DocExamples\` lacks \`coverlet.collector\`. \`dotnet test --collect:\"XPlat Code Coverage\"\` needs the collector referenced by each project it runs; DocExamples is the one currently reached, so it's the one that errored:

\`\`\`
Data collection : Unable to find a datacollector with friendly name 'XPlat Code Coverage'.
\`\`\`

Fix: add \`coverlet.collector\` **10.0.1** (matching Tests.Unit) to every test project that was missing it — DocExamples (the currently-failing site), plus Allocation / Concurrency / Fuzz / Snapshots (currently latent; would break the same way if the coverage run were broadened).

## Test plan
Verified locally with:
\`\`\`
dotnet test tests/Wolfgang.Etl.Transformers.Tests.DocExamples/*.csproj \
    --collect:\"XPlat Code Coverage\"
\`\`\`
which now emits \`coverage.cobertura.xml\` (previously errored). All 320 unit tests + 1 doc-example test pass.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)