### PR TITLE
test(coverage): instrument 5 specialty suites and raise 3 more to 100% (#218 Phase 2)

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/AllocationBudgetTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/AllocationBudgetTests.cs
@@ -42,6 +42,23 @@ public sealed class AllocationBudgetTests
     }
 
 
+    // Sanity: none of the allocation-budget tests above ENUMERATE `source`, they just measure
+    // the wrap. That means the RangeAsync iterator's state machine is never advanced by those
+    // tests, so this companion happy-path test both proves the source works and exercises the
+    // iterator body for coverage.
+    [Fact]
+    public async Task RangeAsync_helper_yields_expected_sequence()
+    {
+        var items = new List<int>();
+        await foreach (var i in RangeAsync(4))
+        {
+            items.Add(i);
+        }
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, items);
+    }
+
+
     /// <summary>
     /// The single-argument <see cref="PassThroughTransformer{T}.TransformAsync(IAsyncEnumerable{T})"/>
     /// overload is documented to return the source sequence directly, without allocating a

--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
@@ -25,6 +25,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/CoyoteEntryPoints.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/CoyoteEntryPoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Coyote.SystematicTesting;
 
@@ -9,6 +10,7 @@ namespace Wolfgang.Etl.Transformers.Tests.Concurrency;
 /// iteration budget (<c>coyote test ... -m &lt;method&gt; -i 10000</c>), exploring thousands
 /// of schedule interleavings to surface races and deadlocks.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Coyote-only entry points — invoked by `coyote test`, not by xunit. The scenarios these delegate to are exercised (and covered) via ConcurrencyStressTests.")]
 public static class CoyoteEntryPoints
 {
     [Test]

--- a/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Scenarios.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Scenarios.cs
@@ -81,26 +81,27 @@ internal static class Scenarios
         using var cts = new CancellationTokenSource();
         var buffered = new BufferedTransformer<int>(4);
 
+        // ReSharper disable once AccessToDisposedClosure — consumer is awaited below before `using var cts` exits, so cts is alive for the closure's full lifetime.
         async Task ConsumeAsync()
         {
-            try
+            await foreach (var _ in buffered.TransformAsync(RangeAsync(ItemCount))
+                .WithCancellation(cts.Token)
+                .ConfigureAwait(false))
             {
-                // ReSharper disable once AccessToDisposedClosure — consumer is awaited before `using var cts` exits, so cts is alive for the closure's full lifetime.
-                await foreach (var _ in buffered.TransformAsync(RangeAsync(ItemCount))
-                    .WithCancellation(cts.Token)
-                    .ConfigureAwait(false))
-                {
-                }
-            }
-            catch (System.OperationCanceledException)
-            {
-                // Expected when cancellation wins the race.
             }
         }
 
         var consumer = ConsumeAsync();
         cts.Cancel();
-        await consumer.ConfigureAwait(false);
+        try
+        {
+            await consumer.ConfigureAwait(false);
+        }
+        catch (System.OperationCanceledException)
+        {
+            // Expected when cancellation wins the race — the scenario asserts the pipeline doesn't
+            // deadlock; whether OCE surfaces or the enumeration finishes first is fine.
+        }
 
         Specification.Assert(true, "Cancellation during buffered enumeration must not deadlock.");
     }

--- a/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
@@ -36,6 +36,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -261,12 +262,17 @@ public sealed class DocExampleCompilationTests
             directory = directory.Parent;
         }
 
-        throw new DirectoryNotFoundException
-        (
-            "Could not locate 'src/Wolfgang.Etl.Transformers' by walking up from " + AppContext.BaseDirectory
-        );
+        return ThrowSrcDirectoryNotFound();
     }
 
+
+    [ExcludeFromCodeCoverage(Justification = "Defensive throw for a shape the CI layout doesn't produce — tests always run from within the repo, so the walk always finds src/. Extracted so the surrounding walk stays measured while this arm is legitimately unreachable.")]
+    private static string ThrowSrcDirectoryNotFound()
+        => throw new DirectoryNotFoundException(
+            "Could not locate 'src/Wolfgang.Etl.Transformers' by walking up from " + AppContext.BaseDirectory);
+
+
+    [ExcludeFromCodeCoverage(Justification = "Diagnostics formatter for the failure path. When examples pass — as they must for CI to be green — this helper is unreached. It's tested implicitly the first time a doc example fails to compile.")]
     private static string FormatFailure(string file, int line, string code, IEnumerable<Diagnostic> diagnostics)
     {
         var indentedCode = string.Join

--- a/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
@@ -25,6 +25,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
@@ -28,6 +28,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
@@ -29,6 +29,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Phase 2 of [#218](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/218) — extends the \`IncludeTestAssembly\` measurement (turned on in Phase 1 via #223) to the six specialty suites and brings each as close to 100% as inherent constraints allow.

## Coverage delta

| suite | before | after | notes |
|---|--:|--:|---|
| Fuzz | 100.00% | 100.00% | no dead code once instrumented |
| Integration | 100.00% | 100.00% | already had coverlet.collector |
| Snapshots | 100.00% | 100.00% | no dead code once instrumented |
| Allocation | 90.24% | **100.00%** | happy-path test for the RangeAsync iterator |
| Concurrency | 92.00% | **97.87%** | CoyoteEntryPoints excluded; try/catch hoisted |
| DocExamples | 86.92% | **98.51%** | failure-formatter + defensive throw excluded |

## What I did

**Allocation** — every alloc-budget test measures the wrap without enumerating the source, so \`RangeAsync\`'s state-machine body was never advanced by any existing test. Added \`RangeAsync_helper_yields_expected_sequence\` (a small consumer test).

**Concurrency**:
- Marked \`CoyoteEntryPoints\` \`[ExcludeFromCodeCoverage]\`. Coyote-only wrappers invoked by \`coyote test\`, not xunit. The scenarios they delegate to are exercised via \`ConcurrencyStressTests\`.
- Restructured \`CancellationDuringEnumerationAsync\`: moved the OCE \`try/catch\` out of the \`ConsumeAsync\` local function into the caller. One line in the caller's try body \`}\` remains uncovered — only reached if the enumeration completes before cancellation wins the race, which defeats the scenario. Accepted at 97.87%.

**DocExamples** — marked two helpers \`[ExcludeFromCodeCoverage]\` with rationale:
- \`FormatFailure\` — diagnostics formatter, only invoked on doc-example rot. Green CI ⇒ dead.
- \`ThrowSrcDirectoryNotFound\` (extracted from \`FindSourceDirectory\`) — defensive path the CI layout doesn't produce.
One line remains uncovered (\`failures.Add(FormatFailure(...))\`) — fires only when rot exists, which is exactly what the test asserts DOESN'T happen. Accepted at 98.51%.

## Coverlet.collector additions
Adds \`coverlet.collector\` 10.0.1 to Allocation / Concurrency / DocExamples / Fuzz / Snapshots. **This duplicates #221 which targets main** — when main flows into vNext post-merge, those csproj lines resolve as no-op merge overlaps.

Refs #218 (Phase 2 of 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)