### PR TITLE
build: bump ETL core packages 0.22.0 → 0.23.1

### DIFF
--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.1" />
   </ItemGroup>
 
 </Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.23.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Bumps the fleet ETL core packages from **0.22.0 → 0.23.1**:

| file | package | old | new |
|---|---|---|---|
| src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj | Wolfgang.Etl.Abstractions | 0.22.0 | **0.23.1** |
| examples/BasicChain/BasicChain.csproj | Wolfgang.Etl.TestKit | 0.22.0 | **0.23.1** |
| examples/LinqOps/LinqOps.csproj | Wolfgang.Etl.TestKit | 0.22.0 | **0.23.1** |

## Test plan
Verified locally:
- \`dotnet build -c Release\` — clean across all TFMs (net462, net472, net47, net471, net48, net481, netstandard2.0, net5.0, net6.0, net7.0, net8.0, net9.0, net10.0)
- \`dotnet test -c Release\` — clean across the full matrix (320 unit + 11 integration + 12 fuzz + 3 concurrency + 3 snapshots + 3 allocation + 1 doc-examples pass on every targeted TFM)

No source changes required — the API surface consumed by this repo is compatible between 0.22 and 0.23.1.

## Note on ordering vs #226
[#226](https://github.com/Chris-Wolfgang/ETL-Transformers/pull/226) (Release 0.5.1) is still open. This PR is base=main, so its diff is against the pre-0.5.1 main. Once #226 merges, this PR's csproj-diff still stands (Version and Abstractions changes touch different lines) — but rebase then, or simply merge #226 first and this one second.

If the intent is to include the 0.23.1 bump IN 0.5.1 rather than as a follow-up, close this PR, cherry-pick the three edits into the vNext branch, and re-open #226's PR body to note the bump. Happy to do that instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)