### PR TITLE
build: bump 9 nuget packages (patch/minor, no code changes required)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.123">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.163">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -111,7 +111,7 @@
   <ItemGroup>
     <!-- SourceLink: embed source provenance into PDBs so debuggers can step
          into NuGet package code from GitHub. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -49,14 +49,14 @@
     prevent NuGet from resolving an older transitive version - no runtime assembly is copied.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.23.1" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Allocation/Wolfgang.Etl.Transformers.Tests.Allocation.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Concurrency/Wolfgang.Etl.Transformers.Tests.Concurrency.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Coyote" Version="1.7.11" />
     <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Fuzz/Wolfgang.Etl.Transformers.Tests.Fuzz.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsCheck" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="CsCheck" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Integration/Wolfgang.Etl.Transformers.Tests.Integration.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Snapshots/Wolfgang.Etl.Transformers.Tests.Snapshots.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/Wolfgang.Etl.Transformers.Tests.Unit.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Routine dependency-hygiene PR. Bumps 9 packages to their latest stable versions on nuget.org. All bumps are patch/minor within their major line; no source changes required.

## Runtime dependencies (aligned across pre-net8 TFMs)
| package | old | new |
|---|---|---|
| Microsoft.Bcl.AsyncInterfaces | 10.0.9 | **10.0.11** |
| Microsoft.Bcl.Memory | 10.0.9 | **10.0.11** |
| System.Threading.Channels | 10.0.9 | **10.0.11** |

## Test infrastructure
| package | old | new |
|---|---|---|
| Microsoft.NET.Test.Sdk | 18.7.0 | **18.9.0** |
| CsCheck | 4.7.0 | **4.8.0** |
| Microsoft.SourceLink.GitHub | 10.0.300 | **10.0.400** |

Only bumps the modern 18.x band of Microsoft.NET.Test.Sdk; the two conditional 17.13.0 references (net5.0 / netcoreapp3.1 target combos where 18.x doesn't ship) stay in place.

## Analyzers (compile-time only)
| package | old | new |
|---|---|---|
| Roslynator.Analyzers | 4.15.0 | **4.16.1** |
| Meziantou.Analyzer | 3.0.123 | **3.0.163** |
| SonarAnalyzer.CSharp | 10.29.0.143774 | **10.32.0.713** |

Release build has \`TreatWarningsAsErrors=true\` and analyzers can add new rules across minor bumps. Verified locally that no new warnings surface at Release.

## Deferred (each wants its own PR + compatibility pass)
| package | old | new | why deferred |
|---|---|---|---|
| xunit.runner.visualstudio | 2.8.2 | 4.0.0 | v4 runner is for xunit v3; repo uses xunit v2.9.3. Would require full v3 migration. |
| Microsoft.CodeAnalysis.CSharp | 4.14.0 | 5.9.0 | Roslyn 4.x → 5.x. Used by Tests.DocExamples' compile-and-collect logic; API may have shifted. |

## Test plan
- \`dotnet build -c Release\` — clean across all TFMs (net462, net47, net471, net472, net48, net481, netstandard2.0, net5.0, net6.0, net7.0, net8.0, net9.0, net10.0)
- \`dotnet test -c Release\` — **326** unit + **11** integration + **12** fuzz + **3** concurrency + **3** snapshots + **4** allocation + **1** doc-examples pass on every TFM they target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)