### PR TITLE
build: bump Microsoft.CodeAnalysis.CSharp 4.14.0 → 5.9.0 (Tests.DocExamples)

### DIFF
--- a/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.Transformers.Tests.DocExamples/Wolfgang.Etl.Transformers.Tests.DocExamples.csproj
@@ -11,6 +11,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- NU1603 is Warning-As-Error under Release: Microsoft.CodeAnalysis.CSharp 5.9.0
+         declares a floor dep on Microsoft.CodeAnalysis.Analyzers 5.9.0-1.26328.17
+         (a preview build) but NuGet resolves the stable 5.9.0 instead — semantically
+         equivalent, but NU1603 flags the substitution. It's a restore-time warning,
+         so the per-PackageReference NoWarn attribute doesn't reach it; project-level
+         NoWarn does. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">


### PR DESCRIPTION
## Summary
Roslyn major bump for the one place it's used: \`Tests.DocExamples\`, which compiles every XML-doc \`<example><code>\` block against the current public API to catch doc rot.

## Result
**Zero source changes required.** The APIs the test uses — \`CSharpSyntaxTree.ParseText\`, \`CSharpParseOptions\`, \`LanguageVersion\`, \`CSharpCompilation\`, \`CSharpCompilationOptions\`, \`DocumentationCommentTriviaSyntax\` — are all still valid in 5.x.

## The one wrinkle: NU1603
5.9.0 declares a floor dep on \`Microsoft.CodeAnalysis.Analyzers 5.9.0-1.26328.17\` (a preview build). NuGet resolves the stable 5.9.0 instead — semantically equivalent, but the substitution trips **NU1603**, which is a warning that gets promoted to error under Release's \`TreatWarningsAsErrors=true\`.

Suppressed at project level:

\`\`\`xml
<NoWarn>$(NoWarn);NU1603</NoWarn>
\`\`\`

Note: the per-\`PackageReference\` \`NoWarn\` attribute doesn't work here — NU1603 fires during NuGet restore, before the package-scoped attribute takes effect. Project-level \`<NoWarn>\` catches it.

## Test plan
- \`dotnet build -c Release\` — clean across the whole solution (**0 warnings, 0 errors**)
- \`dotnet test\` on Tests.DocExamples — 1/1 passes on net10.0

## Stacks
Base is main. Independent of #228 (safe-package bumps) — different files. Merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)