### PR TITLE
chore: address 3 new InspectCode alerts from SonarAnalyzer 10.32 bump

### DIFF
--- a/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereTransformerWithBase.cs
+++ b/benchmarks/Wolfgang.Etl.Transformers.Benchmarks/WhereTransformerWithBase.cs
@@ -66,7 +66,13 @@ public sealed class WhereTransformerWithBase<T> : TransformerBase<T, T, Report>
             }
             else
             {
+                // Sonar S8969 claims the compiler already knows _asyncPredicate is non-null here
+                // via the outer `if (_syncPredicate is not null) ... else ...` branch. It doesn't:
+                // C# nullable flow analysis doesn't correlate two independent field states, and
+                // removing the `!` produces CS8602. Suppressing Sonar with the pragma below.
+#pragma warning disable S8969
                 passed = await _asyncPredicate!(item).ConfigureAwait(continueOnCapturedContext: false);
+#pragma warning restore S8969
             }
 
             if (!passed)

--- a/src/Wolfgang.Etl.Transformers/BufferedTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/BufferedTransformer.cs
@@ -190,10 +190,11 @@ public sealed class BufferedTransformer<T> : ITransformAsync<T, T>
         try
         {
             // Observe cancellation BEFORE MoveNextAsync — see issue #209.
-            // `items.WithCancellation(token)` only offers the token to the source's enumerator;
-            // a plain sequence-backed source will still yield its first element before honoring it,
-            // so without this pre-check one item is silently drained (and, into a Channel, lost
-            // between source and downstream) when the caller hands us an already-cancelled token.
+            // Calling WithCancellation on the source below only OFFERS the token to the
+            // source's enumerator; a plain sequence-backed source will still yield its
+            // first element before honouring it, so without this pre-check one item is
+            // silently drained (and, into a Channel, lost between source and downstream)
+            // when the caller hands us an already-cancelled token.
             token.ThrowIfCancellationRequested();
 
             await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))

--- a/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/PassThroughTransformer.cs
@@ -118,10 +118,11 @@ public sealed class PassThroughTransformer<T> : ITransformWithCancellationAsync<
     )
     {
         // Observe cancellation BEFORE MoveNextAsync — see issue #209.
-        // `items.WithCancellation(token)` only offers the token to the source's enumerator; a plain
-        // sequence-backed source will still yield its first element before honoring it. Without this
-        // pre-check one item is silently pulled from a non-replayable source (network stream, DB
-        // cursor, queue) when the caller hands us an already-cancelled token.
+        // Calling WithCancellation on the source below only OFFERS the token to the source's
+        // enumerator; a plain sequence-backed source will still yield its first element before
+        // honouring it. Without this pre-check one item is silently pulled from a non-replayable
+        // source (network stream, DB cursor, queue) when the caller hands us an already-cancelled
+        // token.
         token.ThrowIfCancellationRequested();
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(continueOnCapturedContext: false))

--- a/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
+++ b/src/Wolfgang.Etl.Transformers/ThrottleTransformer.cs
@@ -100,10 +100,10 @@ public sealed class ThrottleTransformer<T> : ITransformAsync<T, T>
     )
     {
         // Observe cancellation BEFORE MoveNextAsync — see issue #209.
-        // `items.WithCancellation(token)` only offers the token to the source's enumerator; a plain
-        // sequence-backed source still yields its first element regardless. Without this pre-check
-        // one item is pulled from a non-replayable source when the caller hands us an already-
-        // cancelled token.
+        // Calling WithCancellation on the source below only OFFERS the token to the source's
+        // enumerator; a plain sequence-backed source still yields its first element regardless.
+        // Without this pre-check one item is pulled from a non-replayable source when the caller
+        // hands us an already-cancelled token.
         token.ThrowIfCancellationRequested();
 
         var hasPrevious = false;

--- a/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
+++ b/tests/Wolfgang.Etl.Transformers.Tests.Unit/ThrottleTransformerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -162,6 +163,7 @@ public class ThrottleTransformerTests
         public List<TimeSpan> Waits { get; } = new();
 
 
+        [SuppressMessage("Major Code Smell", "S1172:Unused method parameters should be removed", Justification = "The CancellationToken is required by the Func<TimeSpan, CancellationToken, Task> delegate signature this method binds to via method-group conversion. `_` marks the intentional discard, but Sonar 10.32+ no longer exempts it.")]
         public Task Record(TimeSpan delay, CancellationToken _)
         {
             Waits.Add(delay);


### PR DESCRIPTION
## Summary
Post-#228 (SonarAnalyzer.CSharp 10.29 → 10.32) added three new enforcements. Each fixed at the source of the finding rather than suppressed globally, following user guidance from #208's rework.

## S125 (commented-out code) — 3 src/ transformers
Sonar's regex flagged the phrase \`items.WithCancellation(token)\` inside the #209 pre-cancellation-check explanatory comments as commented-out code. Rewrote each comment as prose ("Calling WithCancellation on the source below only OFFERS the token...") so the pattern no longer matches. Same fix in:
- BufferedTransformer.cs
- PassThroughTransformer.cs
- ThrottleTransformer.cs

## S1172 (unused method parameter '_') — ThrottleTransformerTests
DelayRecorder.Record's \`CancellationToken _\` parameter is required by the \`Func<TimeSpan, CancellationToken, Task>\` delegate signature this method binds to via method-group conversion; the \`_\` name marks the intentional discard. Sonar 10.32+ no longer exempts \`_\`, so added a \`[SuppressMessage]\` with rationale.

## S8969 (redundant null-forgiving) — WhereTransformerWithBase.cs (benchmarks)
**Sonar was wrong.** Removing the \`!\` on \`_asyncPredicate\` produces CS8602 because C# nullable flow analysis doesn't correlate two independent field states across the outer \`if (_syncPredicate is not null) ... else ...\` branch. Wrapped the line in \`#pragma warning disable/restore S8969\` with a comment explaining the false positive.

## Test plan
- \`dotnet build -c Release\` — clean across all TFMs (0/0 warnings/errors)
- Tests.Unit 326/326 pass on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)