### PR TITLE
build: bump Wolfgang.Etl.Abstractions 0.23.1 → 0.23.2 (closes #233 — ready to tag v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2026-08-17
 
+### Changed
+
+- Bumped **`Wolfgang.Etl.Abstractions` 0.23.1 → 0.23.2** (patch — see the Abstractions
+  release notes for the specific change). Test-only `Wolfgang.Etl.TestKit` reference
+  in the two `examples/` projects bumped to match. No consumer-visible change to this
+  repo's public API surface.
+
 ### Fixed
 
 - **Pre-cancelled `CancellationToken` no longer drains one item from the source**

--- a/examples/BasicChain/BasicChain.csproj
+++ b/examples/BasicChain/BasicChain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.1" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.2" />
   </ItemGroup>
 
 </Project>

--- a/examples/LinqOps/LinqOps.csproj
+++ b/examples/LinqOps/LinqOps.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.1" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.23.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.23.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Consolidates the pending Abstractions bump into the never-shipped **0.5.1** release, per path A from [#233](https://github.com/Chris-Wolfgang/ETL-Transformers/issues/233).

Once this merges, tag \`v0.5.1\` and \`release.yaml\` publishes.

## Changes

| file | package | old | new |
|---|---|---|---|
| src/Wolfgang.Etl.Transformers.csproj | \`Wolfgang.Etl.Abstractions\` | 0.23.1 | **0.23.2** |
| examples/BasicChain/BasicChain.csproj | \`Wolfgang.Etl.TestKit\` | 0.23.1 | **0.23.2** |
| examples/LinqOps/LinqOps.csproj | \`Wolfgang.Etl.TestKit\` | 0.23.1 | **0.23.2** |

Plus a \`### Changed\` entry under \`## [0.5.1] - 2026-08-17\` in \`CHANGELOG.md\` noting the bump. No consumer-visible API change.

## What's *not* changed here
* \`<Version>\` stays at **0.5.1** — already staged in #226.
* \`<PackageValidationBaselineVersion>\` stays at **0.5.0** (last-published on nuget.org) — bumped to 0.5.1 in a standalone follow-up PR AFTER \`release.yaml\` publishes, per \`reference_packagevalidation_baseline_timing\`. Otherwise \`dotnet pack\` fails NU1102.

## Test plan
Verified locally:
* \`dotnet restore\` clean across all TFMs
* \`dotnet build -c Release\` — **0 warnings, 0 errors**
* \`dotnet test -c Release --no-build\` — **27 test-project × TFM combinations pass, 0 failures** (326 unit + 11 integration + 12 fuzz + 3 concurrency + 3 snapshots + 4 allocation + 1 doc-examples on each TFM they target)

## Post-merge (your job)
\`\`\`bash
git tag v0.5.1
git push origin v0.5.1
\`\`\`

\`release.yaml\` fires on the tag push:
- validate tag matches csproj \`<Version>\`
- pack \`.nupkg\` + \`.snupkg\`
- publish to nuget.org via \`NUGET_API_KEY\`
- deploy docs to gh-pages
- attach artifacts to the GitHub Release

Once nuget has \`Wolfgang.Etl.Transformers 0.5.1\` indexed (~3–4 min per \`reference_nuget_publish_cdn_delay\`), open a small follow-up PR bumping \`<PackageValidationBaselineVersion>\` 0.5.0 → 0.5.1 for the next cycle.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)