### PR TITLE
chore: bump PackageValidationBaselineVersion 0.5.0 → 0.5.1

### DIFF
--- a/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
+++ b/src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj
@@ -33,7 +33,7 @@
       CompatibilitySuppressions.xml so they don't recur silently.
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.5.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Post-release follow-up now that **0.5.1 is live on nuget.org**. Advances the ABI-compat baseline so PackageValidation compares future packs against the just-shipped 0.5.1 rather than 0.5.0.

## Why now
Per \`reference_packagevalidation_baseline_timing\`: baseline bumps happen **after** a release publishes, never before — \`dotnet pack\` requires the baseline version to exist on the nuget CDN. Attempting this before publish fails NU1102 (as I discovered earlier this session).

## Verified
\`\`\`
dotnet pack src/Wolfgang.Etl.Transformers/Wolfgang.Etl.Transformers.csproj -c Release
\`\`\`
Clean. The resulting 0.5.1 nupkg vs the 0.5.1 baseline is a no-op ApiCompat comparison (0 warnings, 0 errors) — as expected since no API changed between "the merged code" and "what shipped as 0.5.1".

## Test plan
* CI Stage 1/2/3 tests still pass (nothing behavioural changed)
* pr.yaml's pack + PackageValidation step now points at the 0.5.1 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)